### PR TITLE
feat: integrate stripe checkout

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import axiosClient from "@/app/_utils/axiosClient";
+import { LOCAL_URL } from "@/app/lib/constants";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: "2024-06-20",
+});
+
+export async function POST(req: Request) {
+  try {
+    const { items } = await req.json();
+    const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = [];
+
+    for (const item of items) {
+      const res = await axiosClient.get(`/products/${item.id}`);
+      const product = res.data?.data;
+      if (!product) continue;
+      lineItems.push({
+        price_data: {
+          currency: "eur",
+          product_data: { name: product.title },
+          unit_amount: Math.round(product.price * 100),
+        },
+        quantity: item.quantity,
+      });
+    }
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      line_items: lineItems,
+      success_url: `${LOCAL_URL}/success`,
+      cancel_url: `${LOCAL_URL}/cart`,
+    });
+
+    return NextResponse.json({ sessionId: session.id });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Failed to create session" }, { status: 500 });
+  }
+}

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useContext, useState } from "react";
+import { CartContext, CartContextType } from "../contexts/CartContext";
+import { loadStripe } from "@stripe/stripe-js";
+import { useUser } from "@clerk/nextjs";
+
+const stripePromise = loadStripe(
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY as string
+);
+
+export default function CheckoutPage() {
+  const { cart } = useContext(CartContext) as CartContextType;
+  const { user } = useUser();
+  const [shippingAddress, setShippingAddress] = useState("");
+  const [billingAddress, setBillingAddress] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await user?.update({
+      unsafeMetadata: { shippingAddress, billingAddress },
+    });
+
+    const grouped: { id: number | string; quantity: number }[] = [];
+    const quantities = new Map<number | string, number>();
+    cart.forEach((item) => {
+      const id = item.id;
+      quantities.set(id, (quantities.get(id) || 0) + 1);
+    });
+    quantities.forEach((quantity, id) => {
+      grouped.push({ id, quantity });
+    });
+
+    const res = await fetch("/api/checkout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ items: grouped }),
+    });
+    const data = await res.json();
+    const stripe = await stripePromise;
+    await stripe?.redirectToCheckout({ sessionId: data.sessionId });
+  };
+
+  return (
+    <section className="mx-auto max-w-md p-4">
+      <h1 className="mb-4 text-2xl font-bold">Checkout</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium">Adresse de livraison</label>
+          <input
+            type="text"
+            value={shippingAddress}
+            onChange={(e) => setShippingAddress(e.target.value)}
+            required
+            className="w-full border px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Adresse de facturation</label>
+          <input
+            type="text"
+            value={billingAddress}
+            onChange={(e) => setBillingAddress(e.target.value)}
+            required
+            className="w-full border px-3 py-2"
+          />
+        </div>
+        <button
+          type="submit"
+          className="w-full rounded-sm bg-gray-700 px-5 py-3 text-sm text-gray-100"
+        >
+          Payer
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -1,6 +1,15 @@
 "use client";
 
+import { useContext, useEffect } from "react";
+import { CartContext, CartContextType } from "../contexts/CartContext";
+
 export default function SuccessPage() {
+  const { clearCart } = useContext(CartContext) as CartContextType;
+
+  useEffect(() => {
+    clearCart();
+  }, [clearCart]);
+
   return (
     <section className="mx-auto max-w-md p-4 text-center">
       <h1 className="mb-4 text-2xl font-bold">Paiement confirmé</h1>


### PR DESCRIPTION
## Summary
- build checkout form to capture addresses and redirect to Stripe
- add API route to create Stripe checkout sessions using product prices from Strapi
- clear cart and local storage after successful payment

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c19aca28a4833391bb6c099cfb7635