### PR TITLE
feat: integrate stripe checkout

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import productApi from "@/app/_utils/productApis";
+import { LOCAL_URL } from "@/app/lib/constants";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: "2024-06-20",
+});
+
+export async function POST(req: Request) {
+  try {
+    const { items } = await req.json();
+    const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = [];
+
+    for (const item of items) {
+      try {
+        const res = await productApi.getProductById(String(item.id));
+        const product = res?.data?.data?.[0];
+        const attrs = product?.attributes;
+        if (!product?.id || !attrs) continue;
+
+        lineItems.push({
+          price_data: {
+            currency: "eur",
+            product_data: { name: attrs.title },
+            unit_amount: Math.round((attrs.price ?? 0) * 100),
+          },
+          quantity: item.quantity,
+        });
+      } catch (err) {
+        console.error(`Failed to fetch product ${item.id}`, err);
+      }
+    }
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      line_items: lineItems,
+      success_url: `${LOCAL_URL}/success`,
+      cancel_url: `${LOCAL_URL}/cart`,
+    });
+
+    return NextResponse.json({ url: session.url });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Failed to create session" }, { status: 500 });
+  }
+}

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useContext, useState } from "react";
+import { CartContext, CartContextType } from "../contexts/CartContext";
+import { useUser } from "@clerk/nextjs";
+
+export default function CheckoutPage() {
+  const { cart } = useContext(CartContext) as CartContextType;
+  const { user } = useUser();
+  const [shippingAddress, setShippingAddress] = useState("");
+  const [billingAddress, setBillingAddress] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await user?.update({
+      unsafeMetadata: { shippingAddress, billingAddress },
+    });
+
+    const grouped: { id: number | string; quantity: number }[] = [];
+    const quantities = new Map<number | string, number>();
+    cart.forEach((item) => {
+      const id = item.id;
+      quantities.set(id, (quantities.get(id) || 0) + 1);
+    });
+    quantities.forEach((quantity, id) => {
+      grouped.push({ id, quantity });
+    });
+
+    const res = await fetch("/api/checkout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ items: grouped }),
+    });
+    const data = await res.json();
+    if (data.url) {
+      window.location.href = data.url;
+    } else {
+      console.error("Failed to create checkout session", data);
+    }
+  };
+
+  return (
+    <section className="mx-auto max-w-md p-4">
+      <h1 className="mb-4 text-2xl font-bold">Checkout</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium">Adresse de livraison</label>
+          <input
+            type="text"
+            value={shippingAddress}
+            onChange={(e) => setShippingAddress(e.target.value)}
+            required
+            className="w-full border px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Adresse de facturation</label>
+          <input
+            type="text"
+            value={billingAddress}
+            onChange={(e) => setBillingAddress(e.target.value)}
+            required
+            className="w-full border px-3 py-2"
+          />
+        </div>
+        <button
+          type="submit"
+          className="w-full rounded-sm bg-gray-700 px-5 py-3 text-sm text-gray-100"
+        >
+          Payer
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/app/contexts/CartContext.tsx
+++ b/app/contexts/CartContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useEffect, useState } from "react";
+import { createContext, useCallback, useEffect, useState } from "react";
 
 export type CartItem = {
   id: string | number;
@@ -40,11 +40,11 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
     localStorage.setItem("cart", JSON.stringify(cart));
   }, [cart]);
 
-  const addToCart = (item: CartItem) => {
+  const addToCart = useCallback((item: CartItem) => {
     setCart((prev) => [...prev, item]);
-  };
+  }, []);
 
-  const removeFromCart = (id: string | number) => {
+  const removeFromCart = useCallback((id: string | number) => {
     setCart((prev) => {
       const index = prev.findIndex((item) => item.id === id);
       if (index === -1) return prev;
@@ -52,12 +52,12 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
       updated.splice(index, 1);
       return updated;
     });
-  };
+  }, []);
 
-  const clearCart = () => {
+  const clearCart = useCallback(() => {
     setCart([]);
     localStorage.removeItem("cart");
-  };
+  }, []);
 
   return (
     <CartContext.Provider value={{ cart, addToCart, removeFromCart, clearCart }}>

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -1,6 +1,71 @@
 "use client";
 
+import { useContext, useEffect } from "react";
+import { useUser } from "@clerk/nextjs";
+import { CartContext, CartContextType } from "../contexts/CartContext";
+import productApi from "../_utils/productApis";
+import orderApi from "../_utils/orderApis";
+
 export default function SuccessPage() {
+  const { cart, clearCart } = useContext(CartContext) as CartContextType;
+  const { user, isLoaded } = useUser();
+
+  useEffect(() => {
+    const recordOrder = async () => {
+      if (!user || cart.length === 0) return;
+
+      try {
+        const quantities = new Map<string | number, number>();
+        cart.forEach((item) => {
+          quantities.set(item.id, (quantities.get(item.id) || 0) + 1);
+        });
+
+        let subtotal = 0;
+        const products: { product: string | number; quantity: number }[] = [];
+        for (const [id, quantity] of quantities) {
+          try {
+            const res = await productApi.getProductById(String(id));
+            const product = res.data?.data?.[0];
+            const price = product?.attributes?.price ?? 0;
+            subtotal += price * quantity;
+            products.push({ product: id, quantity });
+          } catch (err) {
+            console.error(`Failed to fetch product ${id}`, err);
+          }
+        }
+
+        const shipping = { carrier: "standard", price: 0 };
+        const total = subtotal + shipping.price;
+
+        const unsafe = user.unsafeMetadata as Record<string, unknown> | undefined;
+
+        await orderApi.createOrder({
+          data: {
+            userId: user.id,
+            userEmail: user.primaryEmailAddress?.emailAddress,
+            products,
+            shipping,
+            subtotal,
+            total,
+            paymentStatus: "paid",
+            address: {
+              fullName: user.fullName,
+              email: user.primaryEmailAddress?.emailAddress,
+              address: (unsafe?.shippingAddress as string) ?? "",
+            },
+          },
+        });
+        clearCart();
+      } catch (err) {
+        console.error("Failed to record order", err);
+      }
+    };
+
+    if (isLoaded && cart.length) {
+      recordOrder();
+    }
+  }, [cart, clearCart, user, isLoaded]);
+
   return (
     <section className="mx-auto max-w-md p-4 text-center">
       <h1 className="mb-4 text-2xl font-bold">Paiement confirmé</h1>


### PR DESCRIPTION
## Summary
- build checkout form to capture addresses and redirect to Stripe
- add API route to create Stripe checkout sessions using product prices from Strapi
- clear cart and local storage after successful payment
- redirect to session URL to avoid missing session id error
- handle product lookup failures gracefully in checkout route
- stabilize cart context actions to avoid infinite re-renders on success page
- save completed orders to Strapi before emptying the cart
- include product quantities when recording orders and log failures
- ensure orders are recorded only after Clerk user loads and clear cart after successful save
- use product attributes from Strapi when creating Stripe line items

## Testing
- `npm run lint` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c19aca28a4833391bb6c099cfb7635