### PR TITLE
feat: add stripe checkout and order flow

### DIFF
--- a/app/api/create-checkout-session/route.ts
+++ b/app/api/create-checkout-session/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import axiosClient from "@/app/_utils/axiosClient";
+import { LOCAL_URL, STRIPE_SECRET_KEY } from "@/app/lib/constants";
+
+export async function POST(req: Request) {
+  try {
+    const { products } = await req.json();
+
+    if (!Array.isArray(products) || products.length === 0) {
+      return NextResponse.json({ error: "No products provided" }, { status: 400 });
+    }
+
+    const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = [];
+
+    for (const id of products) {
+      try {
+        const res = await axiosClient.get(`/products/${id}?populate=*`);
+        const data = res?.data?.data;
+        const price = data?.price ?? 0;
+        const title = data?.title ?? "Item";
+        lineItems.push({
+          price_data: {
+            currency: "eur",
+            product_data: { name: title },
+            unit_amount: price,
+          },
+          quantity: 1,
+        });
+      } catch (e) {
+        console.error("Product fetch error", e);
+      }
+    }
+
+    const stripe = new Stripe(STRIPE_SECRET_KEY || "", {
+      apiVersion: "2022-11-15",
+    });
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      line_items: lineItems,
+      success_url: `${LOCAL_URL}/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${LOCAL_URL}/checkout`,
+    });
+
+    return NextResponse.json({ id: session.id, url: session.url });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: "Unable to create session" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import React, { useContext, useEffect, useState } from "react";
+import { CartContext, CartContextType } from "../contexts/CartContext";
+import productApi from "@/app/_utils/productApis";
+import { loadStripe } from "@stripe/stripe-js";
+import { STRIPE_PUBLIC_KEY } from "@/app/lib/constants";
+import { useUser } from "@clerk/nextjs";
+
+const stripePromise = loadStripe(STRIPE_PUBLIC_KEY || "");
+
+type Address = {
+  fullName: string;
+  company?: string;
+  address1: string;
+  address2?: string;
+  postalCode: string;
+  city: string;
+  country: string;
+  phone: string;
+};
+
+export default function Checkout() {
+  const { cart } = useContext(CartContext) as CartContextType;
+  const productIds = cart.map((item) => item.id);
+  const [address, setAddress] = useState<Address>({
+    fullName: "",
+    company: "",
+    address1: "",
+    address2: "",
+    postalCode: "",
+    city: "",
+    country: "",
+    phone: "",
+  });
+  const [subtotal, setSubtotal] = useState(0);
+  const shippingPrice = 500;
+  const { user } = useUser();
+
+  useEffect(() => {
+    async function fetchPrices() {
+      let total = 0;
+      for (const id of productIds) {
+        try {
+          const res = await productApi.getProductById(String(id));
+          const data = res?.data?.data?.[0] ?? res?.data?.data;
+          total += data?.price ?? 0;
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      setSubtotal(total);
+    }
+    if (productIds.length) fetchPrices();
+  }, [productIds]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { name, value } = e.target;
+    setAddress((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await user?.update({ unsafeMetadata: { address } });
+    const res = await fetch("/api/create-checkout-session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ products: productIds, address }),
+    });
+    const data = await res.json();
+    const stripe = await stripePromise;
+    if (stripe && data.id) {
+      await stripe.redirectToCheckout({ sessionId: data.id });
+    } else if (data.url) {
+      window.location.href = data.url;
+    }
+  };
+
+  return (
+    <div className="max-w-lg mx-auto p-6">
+      <h1 className="text-2xl font-semibold mb-4">Checkout</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          name="fullName"
+          placeholder="Full Name"
+          value={address.fullName}
+          onChange={handleChange}
+          className="w-full border p-2"
+          required
+        />
+        <input
+          name="company"
+          placeholder="Company"
+          value={address.company}
+          onChange={handleChange}
+          className="w-full border p-2"
+        />
+        <input
+          name="address1"
+          placeholder="Address"
+          value={address.address1}
+          onChange={handleChange}
+          className="w-full border p-2"
+          required
+        />
+        <input
+          name="address2"
+          placeholder="Address 2"
+          value={address.address2}
+          onChange={handleChange}
+          className="w-full border p-2"
+        />
+        <input
+          name="postalCode"
+          placeholder="Postal Code"
+          value={address.postalCode}
+          onChange={handleChange}
+          className="w-full border p-2"
+          required
+        />
+        <input
+          name="city"
+          placeholder="City"
+          value={address.city}
+          onChange={handleChange}
+          className="w-full border p-2"
+          required
+        />
+        <input
+          name="country"
+          placeholder="Country"
+          value={address.country}
+          onChange={handleChange}
+          className="w-full border p-2"
+          required
+        />
+        <input
+          name="phone"
+          placeholder="Phone"
+          value={address.phone}
+          onChange={handleChange}
+          className="w-full border p-2"
+          required
+        />
+        <div className="border-t pt-4">
+          <p>Subtotal: {(subtotal / 100).toFixed(2)} €</p>
+          <p>Shipping: {(shippingPrice / 100).toFixed(2)} €</p>
+          <p className="font-semibold">
+            Total: {((subtotal + shippingPrice) / 100).toFixed(2)} €
+          </p>
+        </div>
+        <button
+          type="submit"
+          className="w-full bg-black text-white p-2 rounded"
+        >
+          Pay with Stripe
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React, { useContext, useEffect } from "react";
+import { useUser } from "@clerk/nextjs";
+import { useSearchParams } from "next/navigation";
+import {
+  CartContext,
+  CartContextType,
+  CartItem,
+} from "../contexts/CartContext";
+import productApi from "@/app/_utils/productApis";
+import orderApis from "@/app/_utils/orderApis";
+
+export default function Success() {
+  const { user } = useUser();
+  const { clearCart } = useContext(CartContext) as CartContextType;
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    async function finalize() {
+      const stored = localStorage.getItem("cart");
+      const cart: CartItem[] = stored ? JSON.parse(stored) : [];
+      const productIds = cart.map((i) => i.id);
+      const sessionId = searchParams.get("session_id");
+      if (sessionId) {
+        console.log("Stripe session:", sessionId);
+      }
+      let subtotal = 0;
+      for (const id of productIds) {
+        try {
+          const res = await productApi.getProductById(String(id));
+          const data = res?.data?.data?.[0] ?? res?.data?.data;
+          subtotal += data?.price ?? 0;
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      const orderData = {
+        data: {
+          orderNumber: `ORD-${Date.now()}`,
+          userId: user?.id,
+          userEmail: user?.primaryEmailAddress?.emailAddress,
+          products: productIds,
+          address: user?.unsafeMetadata?.address || {},
+          shipping: { carrier: "Colissimo", price: 500 },
+          subtotal,
+          total: subtotal + 500,
+          paymentStatus: "paid",
+        },
+      };
+      try {
+        await orderApis.createOrder(orderData);
+      } catch (err) {
+        console.error(err);
+      }
+      clearCart();
+    }
+    finalize();
+  }, [user, clearCart, searchParams]);
+
+  return (
+    <div className="p-6 text-center">
+      <h1 className="text-2xl font-semibold mb-4">Payment Successful</h1>
+      <p>Thank you for your purchase.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add checkout page with address form and Stripe redirection
- implement API route to create Stripe checkout session
- record orders on success and clear cart

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c1da243b088333874d89968b628585