### PR TITLE
feat: add stripe checkout with address and order

### DIFF
--- a/app/_utils/axiosClient.ts
+++ b/app/_utils/axiosClient.ts
@@ -2,11 +2,11 @@ import axios from "axios";
 import { API_KEY, API_URL } from "../lib/constants";
 
 const axiosClient = axios.create({
-    baseURL: API_URL,
-    headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${API_KEY}`,
-    },
+  baseURL: API_URL,
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${API_KEY}`,
+  },
 });
 
-export default axiosClient
+export default axiosClient;

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+import axiosClient from "@/app/_utils/axiosClient";
+import {
+  STRIPE_SECRET_KEY,
+  LOCAL_URL,
+} from "@/app/lib/constants";
+
+const stripe = new Stripe(STRIPE_SECRET_KEY || "", {
+  apiVersion: "2024-06-20",
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const { products = [], address, userId, userEmail } = await req.json();
+
+    const lineItems = [] as Stripe.Checkout.SessionCreateParams.LineItem[];
+
+    for (const id of products) {
+      const res = await axiosClient.get(`/products/${id}`);
+      const data = res.data?.data?.attributes || {};
+      lineItems.push({
+        price_data: {
+          currency: "eur",
+          unit_amount: data.price,
+          product_data: { name: data.title || `Product ${id}` },
+        },
+        quantity: 1,
+      });
+    }
+
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ["card"],
+      line_items: lineItems,
+      mode: "payment",
+      success_url: `${LOCAL_URL}/success`,
+      cancel_url: `${LOCAL_URL}/cart`,
+      metadata: {
+        userId: userId || "",
+        userEmail: userEmail || "",
+        address: JSON.stringify(address || {}),
+        products: JSON.stringify(products || []),
+      },
+    });
+
+    return NextResponse.json({ id: session.id });
+  } catch (error) {
+    console.error(error);
+    return new NextResponse("Stripe error", { status: 500 });
+  }
+}

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useContext, useState, ChangeEvent, FormEvent } from "react";
+import { useUser } from "@clerk/nextjs";
+import { loadStripe } from "@stripe/stripe-js";
+import { CartContext, CartContextType } from "../contexts/CartContext";
+import { STRIPE_PUBLIC_KEY } from "../lib/constants";
+
+const stripePromise = loadStripe(STRIPE_PUBLIC_KEY || "");
+
+type Address = {
+  fullName: string;
+  company?: string;
+  address1: string;
+  address2?: string;
+  postalCode: string;
+  city: string;
+  country: string;
+  phone?: string;
+};
+
+export default function CheckoutPage() {
+  const { cart } = useContext(CartContext) as CartContextType;
+  const { user } = useUser();
+
+  const [address, setAddress] = useState<Address>({
+    fullName: "",
+    company: "",
+    address1: "",
+    address2: "",
+    postalCode: "",
+    city: "",
+    country: "",
+    phone: "",
+  });
+
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement>
+  ) => {
+    const { name, value } = e.target;
+    setAddress((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!cart.length) return;
+
+    // store address in Clerk unsafeMetadata
+    await user?.update({
+      unsafeMetadata: { ...(user.unsafeMetadata || {}), address },
+    });
+
+    const products = cart.map((item) => item.id);
+
+    const res = await fetch("/api/checkout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        products,
+        address,
+        userId: user?.id,
+        userEmail: user?.primaryEmailAddress?.emailAddress,
+      }),
+    });
+
+    const data = await res.json();
+    const stripe = await stripePromise;
+    await stripe?.redirectToCheckout({ sessionId: data.id });
+  };
+
+  return (
+    <section className="mx-auto max-w-screen-md px-4 py-8">
+      <h1 className="mb-4 text-2xl font-bold">Checkout</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          name="fullName"
+          placeholder="Full name"
+          value={address.fullName}
+          onChange={handleChange}
+          className="w-full border px-2 py-1"
+          required
+        />
+        <input
+          name="company"
+          placeholder="Company"
+          value={address.company}
+          onChange={handleChange}
+          className="w-full border px-2 py-1"
+        />
+        <input
+          name="address1"
+          placeholder="Address line 1"
+          value={address.address1}
+          onChange={handleChange}
+          className="w-full border px-2 py-1"
+          required
+        />
+        <input
+          name="address2"
+          placeholder="Address line 2"
+          value={address.address2}
+          onChange={handleChange}
+          className="w-full border px-2 py-1"
+        />
+        <input
+          name="postalCode"
+          placeholder="Postal code"
+          value={address.postalCode}
+          onChange={handleChange}
+          className="w-full border px-2 py-1"
+          required
+        />
+        <input
+          name="city"
+          placeholder="City"
+          value={address.city}
+          onChange={handleChange}
+          className="w-full border px-2 py-1"
+          required
+        />
+        <input
+          name="country"
+          placeholder="Country"
+          value={address.country}
+          onChange={handleChange}
+          className="w-full border px-2 py-1"
+          required
+        />
+        <input
+          name="phone"
+          placeholder="Phone"
+          value={address.phone}
+          onChange={handleChange}
+          className="w-full border px-2 py-1"
+        />
+        <button
+          type="submit"
+          className="rounded-sm bg-gray-700 px-5 py-2 text-sm text-gray-100"
+        >
+          Pay with Stripe
+        </button>
+      </form>
+    </section>
+  );
+}
+

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -63,7 +63,11 @@ export default function CheckoutPage() {
       }),
     });
 
-    const data = await res.json();
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data?.id) {
+      console.error("Checkout error", data);
+      return;
+    }
     const stripe = await stripePromise;
     await stripe?.redirectToCheckout({ sessionId: data.id });
   };

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useContext, useEffect } from "react";
+import { useUser } from "@clerk/nextjs";
+import orderApis from "../_utils/orderApis";
+import { CartContext, CartContextType } from "../contexts/CartContext";
+import axiosClient from "../_utils/axiosClient";
+
+export default function SuccessPage() {
+  const { cart, clearCart } = useContext(CartContext) as CartContextType;
+  const { user } = useUser();
+
+  useEffect(() => {
+    const createOrder = async () => {
+      try {
+        const products = cart.map((item) => item.id);
+        const prices = await Promise.all(
+          products.map(async (id) => {
+            const res = await axiosClient.get(`/products/${id}`);
+            return res.data?.data?.attributes?.price || 0;
+          })
+        );
+        const subtotal = prices.reduce((a, b) => a + b, 0);
+        await orderApis.createOrder({
+          data: {
+            userId: user?.id,
+            userEmail: user?.primaryEmailAddress?.emailAddress,
+            products,
+            address: user?.unsafeMetadata?.address,
+            subtotal,
+            total: subtotal,
+            paymentStatus: "paid",
+          },
+        });
+      } catch (error) {
+        console.error(error);
+      } finally {
+        clearCart();
+      }
+    };
+    if (cart.length) createOrder();
+  }, [cart, clearCart, user]);
+
+  return (
+    <section className="mx-auto max-w-screen-md px-4 py-8 text-center">
+      <h1 className="mb-4 text-2xl font-bold">Paiement réussi</h1>
+      <p>Merci pour votre achat.</p>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add checkout page with address form and Stripe redirection
- create API route to build secure Stripe checkout session
- store orders on success and clear cart

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1de9cace483339a999ba17d805fda