### PR TITLE
feat: integrate stripe checkout

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,0 +1,31 @@
+import Stripe from "stripe";
+import { NextResponse } from "next/server";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string);
+
+export async function POST(request: Request) {
+  const { items } = await request.json();
+
+  const line_items = (items || []).map(
+    (item: { title?: string; price?: number; quantity: number }) => ({
+      price_data: {
+        currency: "eur",
+        product_data: { name: item.title },
+        unit_amount: Math.round((item.price || 0) * 100),
+      },
+      quantity: item.quantity,
+    })
+  );
+
+  const origin = request.headers.get("origin") || "";
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "payment",
+    payment_method_types: ["card"],
+    line_items,
+    success_url: `${origin}/success`,
+    cancel_url: `${origin}/cart`,
+  });
+
+  return NextResponse.json({ url: session.url });
+}

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-//test
+
 import { useContext } from "react";
 import {
   CartContext,
@@ -7,6 +7,19 @@ import {
   CartItem,
 } from "../contexts/CartContext";
 import { SERVER_URL } from "../lib/constants";
+
+async function createCheckoutSession(items: {
+  title?: string;
+  price?: number;
+  quantity: number;
+}[]) {
+  const res = await fetch("/api/checkout", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ items }),
+  });
+  return (await res.json()) as { url?: string };
+}
 
 function CartPage() {
   const { cart, addToCart, removeFromCart } = useContext(
@@ -24,6 +37,18 @@ function CartPage() {
   });
 
   const total = cart.reduce((sum, item) => sum + (item.price || 0), 0);
+
+  const handleCheckout = async () => {
+    const items = Object.values(groups).map(({ item, quantity }) => ({
+      title: item.title,
+      price: item.price,
+      quantity,
+    }));
+    const { url } = await createCheckoutSession(items);
+    if (url) {
+      window.location.href = url;
+    }
+  };
 
   return (
     <section>
@@ -105,12 +130,12 @@ function CartPage() {
                   </dl>
 
                   <div className="flex justify-end">
-                    <a
-                      href="/checkout"
+                    <button
+                      onClick={handleCheckout}
                       className="block rounded-sm bg-gray-700 px-5 py-3 text-sm text-gray-100 transition hover:bg-gray-600"
                     >
                       Checkout
-                    </a>
+                    </button>
                   </div>
                 </div>
               </div>

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useContext, useEffect } from "react";
+import { CartContext, CartContextType } from "../contexts/CartContext";
+
+function SuccessPage() {
+  const { clearCart } = useContext(CartContext) as CartContextType;
+
+  useEffect(() => {
+    clearCart();
+  }, [clearCart]);
+
+  return (
+    <section className="p-8 text-center">
+      <h1 className="text-xl font-bold">Payment successful</h1>
+      <p className="mt-4">Thank you for your purchase.</p>
+    </section>
+  );
+}
+
+export default SuccessPage;


### PR DESCRIPTION
## Summary
- add API route for creating Stripe checkout sessions
- redirect cart checkout button to Stripe and add success page clearing cart

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6b2a4120c8333a49b08e00fe10b26