### PR TITLE
Fix product relation mapping on order creation

### DIFF
--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -49,7 +49,7 @@ function SuccessPage() {
             products: {
               connect: Array.from(
                 new Set(cart.map((item) => Number(item.id)))
-              ),
+              ).map((id) => ({ id })),
             },
             address: {
               fullName: "Jean Dupont",


### PR DESCRIPTION
## Summary
- map product IDs to objects when creating orders so Strapi can connect many-to-many relation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7fe1646308333a9b79c58d9c56527