### PR TITLE
Update success page order payload

### DIFF
--- a/app/_utils/orderApis.ts
+++ b/app/_utils/orderApis.ts
@@ -1,11 +1,8 @@
 import axiosClient from "./axiosClient";
 
 const createOrder = (data: unknown) => axiosClient.post("/orders", data);
-const createOrderLine = (data: unknown) =>
-  axiosClient.post("/order-lines", data);
 
 export default {
   createOrder,
-  createOrderLine,
 };
 

--- a/app/_utils/orderApis.ts
+++ b/app/_utils/orderApis.ts
@@ -1,8 +1,11 @@
 import axiosClient from "./axiosClient";
 
 const createOrder = (data: unknown) => axiosClient.post("/orders", data);
+const createOrderLine = (data: unknown) =>
+  axiosClient.post("/order-lines", data);
 
 export default {
   createOrder,
+  createOrderLine,
 };
 


### PR DESCRIPTION
## Summary
- build order line data with quantity and unit price grouped per product
- send order_line relation creation when creating orders to match the new schema

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c949afbab4833396129c7dfbedc503