### PR TITLE
Fix order line relation payload for Strapi

### DIFF
--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -99,20 +99,15 @@ function SuccessPage() {
 
         if (orderDocumentId && orderLineInputs.length > 0) {
           await Promise.all(
-            orderLineInputs.map(
-              ({ productDocumentId, quantity, unitPrice }) =>
-                orderApis.createOrderLine({
-                  data: {
-                    quantity,
-                    unitPrice,
-                    order: {
-                      connect: [orderDocumentId],
-                    },
-                    product: {
-                      connect: [productDocumentId],
-                    },
-                  },
-                })
+            orderLineInputs.map(({ productDocumentId, quantity, unitPrice }) =>
+              orderApis.createOrderLine({
+                data: {
+                  quantity,
+                  unitPrice,
+                  order: orderDocumentId,
+                  product: productDocumentId,
+                },
+              })
             )
           );
         }


### PR DESCRIPTION
## Summary
- update the order line creation payload to send the related order and product IDs directly, matching Strapi's REST expectations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c99e148a408333a26546d1b36eb00c