### PR TITLE
Integrate Shippo shipping selection before checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,40 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+This project is a [Next.js](https://nextjs.org) e-commerce front-end. It now integrates [Shippo](https://goshippo.com/) to let shoppers pick a carrier before being redirected to Stripe Checkout.
 
-## Getting Started
+## Getting started
 
-First, run the development server:
+Install dependencies and run the development server:
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The app is available at [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Shippo configuration
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Create an `.env.local` file at the project root and configure the following variables with your Shippo credentials and origin address:
 
-## Learn More
+```bash
+SHIPPO_API_TOKEN=your_private_token
+SHIPPO_FROM_NAME=John Doe
+SHIPPO_FROM_COMPANY=My Company            # optional
+SHIPPO_FROM_STREET1=12 Rue des Fleurs
+SHIPPO_FROM_STREET2=Appartement 34        # optional
+SHIPPO_FROM_CITY=Paris
+SHIPPO_FROM_STATE=Île-de-France           # optional
+SHIPPO_FROM_ZIP=75001
+SHIPPO_FROM_COUNTRY=FR
+SHIPPO_FROM_PHONE=+33123456789            # optional
+SHIPPO_FROM_EMAIL=john.doe@example.com    # optional
+SHIPPO_CURRENCY=EUR                       # optional (defaults to EUR)
+```
 
-To learn more about Next.js, take a look at the following resources:
+The checkout flow requests shipping rates from `app/api/shipping-rates`, filters them to the configured currency, and persists the shopper's choice until the Stripe Checkout session completes.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Development workflow
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+- `npm run dev` – start the local development server.
+- `npm run lint` – run ESLint checks.
 
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+When testing the checkout flow locally, make sure your browser can reach the Next.js server (http://localhost:3000) and that the Shippo API token has access to live or test rates for the destination country.

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -4,20 +4,77 @@ import { NextResponse } from "next/server";
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string);
 
 export async function POST(request: Request) {
-  const { items } = await request.json();
+  const { items, shippingRate, shippingAddress } = await request.json();
 
-  const line_items = (items || []).map(
-    (item: { title?: string; price?: number; quantity: number }) => ({
+  const line_items = (items || [])
+    .filter((item: { quantity?: number }) => item && item.quantity > 0)
+    .map((item: { title?: string; price?: number; quantity: number }) => ({
       price_data: {
         currency: "eur",
         product_data: { name: item.title },
-        unit_amount: Math.round((item.price || 0) * 100),
+        unit_amount: Math.round(Math.max(item.price || 0, 0) * 100),
       },
       quantity: item.quantity,
-    })
-  );
+    }));
+
+  if (!Array.isArray(items) || line_items.length === 0) {
+    return NextResponse.json(
+      { error: "Aucun article à régler." },
+      { status: 400 }
+    );
+  }
+
+  if (shippingRate && typeof shippingRate.amount === "number") {
+    const shippingAmountCents = Math.round(
+      Math.max(shippingRate.amount, 0) * 100
+    );
+    const shippingCurrency =
+      typeof shippingRate.currency === "string"
+        ? shippingRate.currency.toLowerCase()
+        : "eur";
+
+    line_items.push({
+      price_data: {
+        currency: shippingCurrency,
+        product_data: {
+          name: `Shipping - ${shippingRate.provider || "Carrier"}`,
+          description: shippingRate.serviceLevelName || undefined,
+        },
+        unit_amount: shippingAmountCents,
+      },
+      quantity: 1,
+    });
+  }
 
   const origin = request.headers.get("origin") || "";
+
+  const metadata: Record<string, string> = {};
+
+  if (shippingRate?.objectId) {
+    metadata.shippo_rate_id = String(shippingRate.objectId);
+  }
+  if (shippingRate?.shipmentId) {
+    metadata.shippo_shipment_id = String(shippingRate.shipmentId);
+  }
+  if (shippingRate?.provider) {
+    metadata.shipping_provider = String(shippingRate.provider);
+  }
+  if (shippingRate?.serviceLevelName) {
+    metadata.shipping_service = String(shippingRate.serviceLevelName);
+  }
+  if (shippingRate?.currency) {
+    metadata.shipping_currency = String(shippingRate.currency);
+  }
+  if (typeof shippingRate?.amount === "number") {
+    metadata.shipping_amount = shippingRate.amount.toString();
+  }
+  if (shippingAddress) {
+    try {
+      metadata.shipping_address = JSON.stringify(shippingAddress);
+    } catch {
+      // ignore serialization issues
+    }
+  }
 
   const session = await stripe.checkout.sessions.create({
     mode: "payment",
@@ -25,6 +82,7 @@ export async function POST(request: Request) {
     line_items,
     success_url: `${origin}/success`,
     cancel_url: `${origin}/cart`,
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
   });
 
   return NextResponse.json({ url: session.url });

--- a/app/api/shipping-rates/route.ts
+++ b/app/api/shipping-rates/route.ts
@@ -1,0 +1,259 @@
+import { NextResponse } from "next/server";
+
+type ShippoAddress = {
+  name?: string;
+  company?: string;
+  street1: string;
+  street2?: string;
+  city: string;
+  state?: string;
+  zip: string;
+  country: string;
+  phone?: string;
+  email?: string;
+};
+
+type ShippoParcel = {
+  length?: string | number;
+  width?: string | number;
+  height?: string | number;
+  distance_unit?: string;
+  weight?: string | number;
+  mass_unit?: string;
+};
+
+type ShippoRateResponse = {
+  object_id: string;
+  amount: string | number;
+  currency?: string;
+  provider: string;
+  servicelevel?: { name?: string; token?: string };
+  servicelevel_name?: string;
+  servicelevel_token?: string;
+  estimated_days?: number;
+  duration_terms?: string;
+  provider_image_75?: string;
+};
+
+type ShippoShipmentResponse = {
+  object_id: string;
+  rates: ShippoRateResponse[];
+};
+
+type ShippoErrorResponse = {
+  detail?: string;
+  message?: string;
+};
+
+const REQUIRED_ENV_VARS = [
+  "SHIPPO_API_TOKEN",
+  "SHIPPO_FROM_NAME",
+  "SHIPPO_FROM_STREET1",
+  "SHIPPO_FROM_CITY",
+  "SHIPPO_FROM_ZIP",
+  "SHIPPO_FROM_COUNTRY",
+];
+
+const TARGET_CURRENCY = process.env.SHIPPO_CURRENCY
+  ? process.env.SHIPPO_CURRENCY.toUpperCase()
+  : "EUR";
+
+function buildAddressFromEnv(): ShippoAddress {
+  return {
+    name: process.env.SHIPPO_FROM_NAME,
+    company: process.env.SHIPPO_FROM_COMPANY,
+    street1: process.env.SHIPPO_FROM_STREET1 as string,
+    street2: process.env.SHIPPO_FROM_STREET2 ?? undefined,
+    city: process.env.SHIPPO_FROM_CITY as string,
+    state: process.env.SHIPPO_FROM_STATE ?? undefined,
+    zip: process.env.SHIPPO_FROM_ZIP as string,
+    country: process.env.SHIPPO_FROM_COUNTRY as string,
+    phone: process.env.SHIPPO_FROM_PHONE ?? undefined,
+    email: process.env.SHIPPO_FROM_EMAIL ?? undefined,
+  };
+}
+
+function normalizeParcel(parcel?: ShippoParcel | null): ShippoParcel {
+  const fallback = {
+    length: "20",
+    width: "15",
+    height: "10",
+    distance_unit: "cm",
+    weight: "1",
+    mass_unit: "kg",
+  } satisfies ShippoParcel;
+
+  if (!parcel) {
+    return fallback;
+  }
+
+  const toStringValue = (value?: string | number) =>
+    typeof value === "number" && Number.isFinite(value)
+      ? value.toString()
+      : value;
+
+  return {
+    length: toStringValue(parcel.length) ?? fallback.length,
+    width: toStringValue(parcel.width) ?? fallback.width,
+    height: toStringValue(parcel.height) ?? fallback.height,
+    distance_unit: parcel.distance_unit ?? fallback.distance_unit,
+    weight: toStringValue(parcel.weight) ?? fallback.weight,
+    mass_unit: parcel.mass_unit ?? fallback.mass_unit,
+  } satisfies ShippoParcel;
+}
+
+function mapAddressToShippo(address: unknown): ShippoAddress | null {
+  if (!address || typeof address !== "object") {
+    return null;
+  }
+
+  const value = address as Record<string, unknown>;
+
+  const street1 =
+    typeof value.address1 === "string"
+      ? value.address1
+      : typeof value.street1 === "string"
+      ? value.street1
+      : null;
+  const city = typeof value.city === "string" ? value.city : null;
+  const postalCode =
+    typeof value.postalCode === "string"
+      ? value.postalCode
+      : typeof value.zip === "string"
+      ? value.zip
+      : null;
+  const country = typeof value.country === "string" ? value.country : null;
+
+  if (!street1 || !city || !postalCode || !country) {
+    return null;
+  }
+
+  return {
+    name:
+      typeof value.fullName === "string"
+        ? value.fullName
+        : typeof value.name === "string"
+        ? value.name
+        : undefined,
+    company: typeof value.company === "string" ? value.company : undefined,
+    street1,
+    street2:
+      typeof value.address2 === "string"
+        ? value.address2
+        : typeof value.street2 === "string"
+        ? value.street2
+        : undefined,
+    city,
+    state: typeof value.state === "string" ? value.state : undefined,
+    zip: postalCode,
+    country,
+    phone: typeof value.phone === "string" ? value.phone : undefined,
+    email: typeof value.email === "string" ? value.email : undefined,
+  } satisfies ShippoAddress;
+}
+
+export async function POST(request: Request) {
+  try {
+    const missingEnv = REQUIRED_ENV_VARS.filter((key) => !process.env[key]);
+    if (missingEnv.length > 0) {
+      return NextResponse.json(
+        {
+          error: `Shippo configuration missing: ${missingEnv.join(", ")}`,
+        },
+        { status: 500 }
+      );
+    }
+
+    const token = process.env.SHIPPO_API_TOKEN as string;
+    const addressFrom = buildAddressFromEnv();
+
+    const { addressTo, parcel, parcels } = await request.json();
+
+    const toAddress = mapAddressToShippo(addressTo);
+    if (!toAddress) {
+      return NextResponse.json(
+        { error: "Adresse de destination invalide" },
+        { status: 400 }
+      );
+    }
+
+    const parcelsPayload: ShippoParcel[] = Array.isArray(parcels)
+      ? parcels.map((item: ShippoParcel | null) => normalizeParcel(item))
+      : [normalizeParcel((parcel as ShippoParcel | null) ?? null)];
+
+    const response = await fetch("https://api.goshippo.com/shipments/", {
+      method: "POST",
+      headers: {
+        Authorization: `ShippoToken ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        address_from: addressFrom,
+        address_to: toAddress,
+        parcels: parcelsPayload,
+        async: false,
+      }),
+    });
+
+    const shipmentBody = (await response
+      .json()
+      .catch(() => null)) as
+      | (ShippoShipmentResponse & ShippoErrorResponse)
+      | ShippoErrorResponse
+      | null;
+
+    if (
+      !response.ok ||
+      !shipmentBody ||
+      !("rates" in shipmentBody) ||
+      !Array.isArray(shipmentBody.rates)
+    ) {
+      const errorBody = shipmentBody as ShippoErrorResponse | null;
+      const errorMessage =
+        errorBody?.detail ||
+        errorBody?.message ||
+        "Impossible de récupérer les tarifs de livraison";
+
+      return NextResponse.json({ error: errorMessage }, { status: 502 });
+    }
+
+    const shipmentData = shipmentBody as ShippoShipmentResponse;
+
+    const rates = shipmentData.rates
+      .map((rate: ShippoRateResponse) => {
+        const currency =
+          typeof rate.currency === "string"
+            ? rate.currency.toUpperCase()
+            : TARGET_CURRENCY;
+
+        return {
+          objectId: rate.object_id,
+          amount: Number(rate.amount),
+          currency,
+          provider: rate.provider,
+          serviceLevelName:
+            rate.servicelevel?.name ?? rate.servicelevel_name ?? "",
+          serviceLevelToken:
+            rate.servicelevel?.token ?? rate.servicelevel_token ?? undefined,
+          estimatedDays: rate.estimated_days ?? null,
+          durationTerms: rate.duration_terms ?? null,
+          shipmentId: shipmentData.object_id,
+          providerImage75: rate.provider_image_75 ?? undefined,
+        };
+      })
+      .filter(
+        (rate) =>
+          Boolean(rate.objectId) &&
+          Number.isFinite(rate.amount) &&
+          rate.currency === TARGET_CURRENCY
+      );
+
+    return NextResponse.json({ rates });
+  } catch (error) {
+    console.error("Failed to fetch Shippo rates", error);
+    return NextResponse.json(
+      { error: "Impossible de récupérer les tarifs de livraison" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -1,45 +1,223 @@
 "use client";
 
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
+
 import {
   CartContext,
   CartContextType,
   CartItem,
+  ShippingAddress,
+  ShippingRate,
 } from "../contexts/CartContext";
 import { SERVER_URL } from "../lib/constants";
 
-async function createCheckoutSession(items: {
+type CheckoutItem = {
   title?: string;
   price?: number;
   quantity: number;
-}[]) {
+};
+
+const CURRENCY_FALLBACK = "EUR";
+
+const ADDRESS_FIELDS: (keyof ShippingAddress)[] = [
+  "fullName",
+  "company",
+  "address1",
+  "address2",
+  "city",
+  "state",
+  "postalCode",
+  "country",
+  "phone",
+  "email",
+];
+
+function formatCurrency(amount: number, currency: string = CURRENCY_FALLBACK) {
+  if (!Number.isFinite(amount)) {
+    return "—";
+  }
+
+  try {
+    return new Intl.NumberFormat("fr-FR", {
+      style: "currency",
+      currency,
+      currencyDisplay: "symbol",
+      minimumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+}
+
+function safeTrim(value?: string | null) {
+  return value?.trim() ?? "";
+}
+
+function normalizeAddress(address: ShippingAddress): ShippingAddress {
+  return {
+    fullName: safeTrim(address.fullName),
+    company: safeTrim(address.company),
+    address1: safeTrim(address.address1),
+    address2: safeTrim(address.address2),
+    city: safeTrim(address.city),
+    state: safeTrim(address.state),
+    postalCode: safeTrim(address.postalCode),
+    country: safeTrim(address.country).toUpperCase(),
+    phone: safeTrim(address.phone),
+    email: safeTrim(address.email),
+  } satisfies ShippingAddress;
+}
+
+function addressesEqual(
+  a?: ShippingAddress | null,
+  b?: ShippingAddress | null
+) {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+
+  const normalizedA = normalizeAddress(a);
+  const normalizedB = normalizeAddress(b);
+
+  return ADDRESS_FIELDS.every((field) => {
+    const valueA = normalizedA[field] ?? "";
+    const valueB = normalizedB[field] ?? "";
+    return valueA === valueB;
+  });
+}
+
+type ParcelInput = {
+  length: string;
+  width: string;
+  height: string;
+  distance_unit: string;
+  weight: string;
+  mass_unit: string;
+};
+
+function buildParcelFromCart(cart: CartItem[]): ParcelInput {
+  const fallbackDimensions = {
+    length: 30,
+    width: 20,
+    height: 10,
+  };
+
+  const referenceItem = cart.find(
+    (item) => item.length && item.width && item.height
+  );
+
+  const totalWeight = cart.reduce((sum, item) => {
+    const weight =
+      typeof item.weight === "number" && Number.isFinite(item.weight)
+        ? item.weight
+        : 0.5;
+    return sum + weight;
+  }, 0);
+
+  const normalizedWeight = Math.max(totalWeight, 0.1);
+
+  const length =
+    typeof referenceItem?.length === "number"
+      ? referenceItem.length
+      : fallbackDimensions.length;
+  const width =
+    typeof referenceItem?.width === "number"
+      ? referenceItem.width
+      : fallbackDimensions.width;
+  const height =
+    typeof referenceItem?.height === "number"
+      ? referenceItem.height
+      : fallbackDimensions.height;
+
+  return {
+    length: length.toString(),
+    width: width.toString(),
+    height: height.toString(),
+    distance_unit: "cm",
+    weight: normalizedWeight.toFixed(2),
+    mass_unit: "kg",
+  } satisfies ParcelInput;
+}
+
+async function createCheckoutSession(payload: {
+  items: CheckoutItem[];
+  shippingRate?: ShippingRate | null;
+  shippingAddress?: ShippingAddress | null;
+}) {
+  const body = {
+    items: payload.items,
+    shippingRate: payload.shippingRate ?? undefined,
+    shippingAddress: payload.shippingAddress ?? undefined,
+  };
+
   const res = await fetch("/api/checkout", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ items }),
+    body: JSON.stringify(body),
   });
-  return (await res.json()) as { url?: string };
+
+  const data = await res.json().catch(() => ({}));
+
+  if (!res.ok) {
+    const message =
+      (data as { error?: string })?.error ??
+      "Le paiement n'a pas pu être démarré.";
+    throw new Error(message);
+  }
+
+  return data as { url?: string };
 }
 
 function CartPage() {
-  const { cart, addToCart, removeFromCart } = useContext(
-    CartContext
-  ) as CartContextType;
+  const {
+    cart,
+    addToCart,
+    removeFromCart,
+    shippingAddress,
+    setShippingAddress,
+    selectedShippingRate,
+    setSelectedShippingRate,
+  } = useContext(CartContext) as CartContextType;
 
-  const groups: { [key: string]: { item: CartItem; quantity: number } } = {};
-  cart.forEach((item) => {
-    const key = item.id.toString();
-    if (groups[key]) {
-      groups[key].quantity += 1;
-    } else {
-      groups[key] = { item, quantity: 1 };
-    }
-  });
+  const groups = useMemo(() => {
+    const result: Record<string, { item: CartItem; quantity: number }> = {};
 
-  const [total, setTotal] = useState(0);
+    cart.forEach((item) => {
+      const key = item.id.toString();
+      if (result[key]) {
+        result[key].quantity += 1;
+      } else {
+        result[key] = { item, quantity: 1 };
+      }
+    });
+
+    return result;
+  }, [cart]);
+
+  const groupedItems = useMemo(() => Object.values(groups), [groups]);
+
+  const [subtotal, setSubtotal] = useState(0);
+  const [shippingRates, setShippingRates] = useState<ShippingRate[]>([]);
+  const [isFetchingRates, setIsFetchingRates] = useState(false);
+  const [isCreatingCheckout, setIsCreatingCheckout] = useState(false);
+  const [shippingError, setShippingError] = useState<string | null>(null);
+  const [isAddressDirty, setIsAddressDirty] = useState(false);
+
+  const [addressForm, setAddressForm] = useState<ShippingAddress>(() => ({
+    fullName: shippingAddress?.fullName ?? "",
+    company: shippingAddress?.company ?? "",
+    address1: shippingAddress?.address1 ?? "",
+    address2: shippingAddress?.address2 ?? "",
+    city: shippingAddress?.city ?? "",
+    state: shippingAddress?.state ?? "",
+    postalCode: shippingAddress?.postalCode ?? "",
+    country: shippingAddress?.country ?? "FR",
+    phone: shippingAddress?.phone ?? "",
+    email: shippingAddress?.email ?? "",
+  }));
 
   useEffect(() => {
-    const map: { [key: string]: number } = {};
+    const map: Record<string, number> = {};
+
     cart.forEach((item) => {
       const key = item.id.toString();
       map[key] = (map[key] || 0) + 1;
@@ -51,7 +229,7 @@ function CartPage() {
     }));
 
     if (items.length === 0) {
-      setTotal(0);
+      setSubtotal(0);
       return;
     }
 
@@ -63,30 +241,247 @@ function CartPage() {
           body: JSON.stringify({ items }),
         });
         const data = await res.json();
-        setTotal(data.total || 0);
+        setSubtotal(data.total || 0);
       } catch (err) {
         console.error("Failed to calculate total", err);
-        setTotal(0);
+        setSubtotal(0);
       }
     })();
   }, [cart]);
 
+  useEffect(() => {
+    if (!shippingAddress) {
+      setAddressForm((prev) => ({
+        ...prev,
+        fullName: "",
+        company: "",
+        address1: "",
+        address2: "",
+        city: "",
+        state: "",
+        postalCode: "",
+        country: prev.country || "FR",
+        phone: "",
+        email: "",
+      }));
+      setIsAddressDirty(false);
+      return;
+    }
+
+    setAddressForm({
+      fullName: shippingAddress.fullName ?? "",
+      company: shippingAddress.company ?? "",
+      address1: shippingAddress.address1,
+      address2: shippingAddress.address2 ?? "",
+      city: shippingAddress.city,
+      state: shippingAddress.state ?? "",
+      postalCode: shippingAddress.postalCode,
+      country: shippingAddress.country,
+      phone: shippingAddress.phone ?? "",
+      email: shippingAddress.email ?? "",
+    });
+    setIsAddressDirty(false);
+  }, [shippingAddress]);
+
+  useEffect(() => {
+    if (cart.length === 0) {
+      setShippingRates([]);
+      setIsAddressDirty(false);
+      setShippingError(null);
+      setSelectedShippingRate(null);
+    }
+  }, [cart.length, setSelectedShippingRate]);
+
+  const handleAddressChange = (
+    field: keyof ShippingAddress,
+    value: string
+  ) => {
+    const normalizedValue =
+      field === "country" ? value.toUpperCase() : value;
+
+    setAddressForm((prev) => {
+      const next = {
+        ...prev,
+        [field]: normalizedValue,
+      } as ShippingAddress;
+
+      if (addressesEqual(next, shippingAddress)) {
+        setIsAddressDirty(false);
+      } else {
+        setIsAddressDirty(true);
+        if (shippingRates.length > 0) {
+          setShippingRates([]);
+        }
+        if (selectedShippingRate) {
+          setSelectedShippingRate(null);
+        }
+      }
+
+      return next;
+    });
+  };
+
+  const handleSelectShippingRate = (rateId: string) => {
+    const rate = shippingRates.find((item) => item.objectId === rateId);
+    if (!rate) return;
+
+    setSelectedShippingRate(rate);
+    setShippingError(null);
+  };
+
+  const handleFetchShippingRates = async () => {
+    if (cart.length === 0) {
+      setShippingError("Ton panier est vide.");
+      return;
+    }
+
+    if (
+      !addressForm.address1 ||
+      !addressForm.city ||
+      !addressForm.postalCode ||
+      !addressForm.country
+    ) {
+      setShippingError(
+        "Renseigne au minimum la rue, la ville, le code postal et le pays pour calculer les transporteurs."
+      );
+      return;
+    }
+
+    setIsFetchingRates(true);
+    setShippingError(null);
+
+    const parcel = buildParcelFromCart(cart);
+    const normalizedShippingAddress = normalizeAddress(addressForm);
+
+    try {
+      const res = await fetch("/api/shipping-rates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          addressTo: normalizedShippingAddress,
+          parcel,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(
+          data?.error ||
+            "Impossible de récupérer les transporteurs disponibles."
+        );
+      }
+
+      const fetchedRates = Array.isArray(data?.rates)
+        ? (data.rates as ShippingRate[])
+        : [];
+
+      const sortedRates = [...fetchedRates].sort(
+        (a, b) => a.amount - b.amount
+      );
+
+      setShippingRates(sortedRates);
+      setShippingAddress(normalizedShippingAddress);
+      setIsAddressDirty(false);
+
+      if (sortedRates.length === 0) {
+        setSelectedShippingRate(null);
+        setShippingError(
+          "Aucun transporteur n'est disponible pour cette adresse."
+        );
+        return;
+      }
+
+      const existingSelection = sortedRates.find(
+        (rate) => rate.objectId === selectedShippingRate?.objectId
+      );
+
+      if (existingSelection) {
+        setSelectedShippingRate(existingSelection);
+      } else {
+        setSelectedShippingRate(sortedRates[0]);
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Impossible de récupérer les transporteurs disponibles.";
+      setShippingError(message);
+    } finally {
+      setIsFetchingRates(false);
+    }
+  };
+
   const handleCheckout = async () => {
-    const items = Object.values(groups).map(({ item, quantity }) => ({
+    if (!selectedShippingRate) {
+      setShippingError(
+        "Sélectionne un transporteur avant de passer au paiement."
+      );
+      return;
+    }
+
+    if (isAddressDirty) {
+      setShippingError(
+        "L’adresse a changé. Relance la recherche des transporteurs avant de poursuivre."
+      );
+      return;
+    }
+
+    const shippingData = shippingAddress ?? normalizeAddress(addressForm);
+
+    if (
+      !shippingData.address1 ||
+      !shippingData.city ||
+      !shippingData.postalCode ||
+      !shippingData.country
+    ) {
+      setShippingError(
+        "Merci de renseigner ton adresse de livraison avant le paiement."
+      );
+      return;
+    }
+
+    const items = groupedItems.map(({ item, quantity }) => ({
       title: item.title,
       price: item.price,
       quantity,
     }));
-    const { url } = await createCheckoutSession(items);
-    if (url) {
-      window.location.href = url;
+
+    setIsCreatingCheckout(true);
+    setShippingError(null);
+
+    try {
+      const { url } = await createCheckoutSession({
+        items,
+        shippingRate: selectedShippingRate,
+        shippingAddress: shippingData,
+      });
+
+      if (url) {
+        window.location.href = url;
+      } else {
+        setShippingError(
+          "Le paiement n'a pas pu être démarré. Réessaie dans quelques instants."
+        );
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Le paiement n'a pas pu être démarré.";
+      setShippingError(message);
+    } finally {
+      setIsCreatingCheckout(false);
     }
   };
+
+  const summaryTotal = subtotal + (selectedShippingRate?.amount ?? 0);
+  const summaryCurrency = selectedShippingRate?.currency ?? CURRENCY_FALLBACK;
 
   return (
     <section>
       <div className="mx-auto max-w-screen-xl px-4 py-8 sm:px-6 sm:py-12 lg:px-8">
-        <div className="mx-auto max-w-3xl">
+        <div className="mx-auto max-w-4xl">
           <header className="text-center">
             <h1 className="text-xl font-bold text-gray-900 sm:text-3xl">
               Your Cart
@@ -94,13 +489,16 @@ function CartPage() {
           </header>
 
           {cart.length === 0 ? (
-            <p className="mt-8 text-center text-gray-500">Your cart is empty.</p>
+            <p className="mt-8 text-center text-gray-500">
+              Your cart is empty.
+            </p>
           ) : (
-            <div className="mt-8">
+            <div className="mt-8 space-y-8">
               <ul className="space-y-4">
-                {Object.values(groups).map(({ item, quantity }) => (
+                {groupedItems.map(({ item, quantity }) => (
                   <li key={item.id} className="flex items-center gap-4">
                     {item.banner?.url && (
+                      // eslint-disable-next-line @next/next/no-img-element
                       <img
                         src={`${SERVER_URL}${item.banner.url}`}
                         alt={item.title}
@@ -114,7 +512,7 @@ function CartPage() {
                       </h3>
                       {item.price !== undefined && (
                         <p className="mt-0.5 text-xs text-gray-600">
-                          {item.price} €
+                          {formatCurrency(item.price, CURRENCY_FALLBACK)}
                         </p>
                       )}
                     </div>
@@ -142,32 +540,356 @@ function CartPage() {
                 ))}
               </ul>
 
-              <div className="mt-8 flex justify-end border-t border-gray-100 pt-8">
-                <div className="w-screen max-w-lg space-y-4">
-                  <div className="flex gap-2">
-                    <input
-                      type="text"
-                      placeholder="Code de réduction"
-                      className="w-full border px-2 py-1 text-sm"
-                    />
-                    <button className="rounded-sm bg-gray-700 px-3 py-1 text-sm text-gray-100">
-                      Ajouter
-                    </button>
+              <div className="space-y-6 border-t border-gray-100 pt-8">
+                <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+                  <div className="space-y-6">
+                    <div className="rounded-sm border border-gray-200 p-4 sm:p-6">
+                      <h2 className="text-lg font-semibold text-gray-900">
+                        Adresse de livraison
+                      </h2>
+                      <p className="mt-1 text-sm text-gray-600">
+                        Indique ton adresse pour afficher les transporteurs
+                        disponibles avant le paiement.
+                      </p>
+
+                      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                        <label className="text-sm">
+                          <span className="mb-1 block text-gray-700">
+                            Nom complet
+                          </span>
+                          <input
+                            type="text"
+                            value={addressForm.fullName ?? ""}
+                            onChange={(event) =>
+                              handleAddressChange(
+                                "fullName",
+                                event.target.value
+                              )
+                            }
+                            className="w-full rounded-sm border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none"
+                          />
+                        </label>
+
+                        <label className="text-sm">
+                          <span className="mb-1 block text-gray-700">
+                            Société (optionnel)
+                          </span>
+                          <input
+                            type="text"
+                            value={addressForm.company ?? ""}
+                            onChange={(event) =>
+                              handleAddressChange(
+                                "company",
+                                event.target.value
+                              )
+                            }
+                            className="w-full rounded-sm border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none"
+                          />
+                        </label>
+
+                        <label className="text-sm sm:col-span-2">
+                          <span className="mb-1 block text-gray-700">
+                            Adresse
+                          </span>
+                          <input
+                            type="text"
+                            value={addressForm.address1}
+                            onChange={(event) =>
+                              handleAddressChange(
+                                "address1",
+                                event.target.value
+                              )
+                            }
+                            className="w-full rounded-sm border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none"
+                            placeholder="Numéro et rue"
+                          />
+                        </label>
+
+                        <label className="text-sm sm:col-span-2">
+                          <span className="mb-1 block text-gray-700">
+                            Complément d’adresse (optionnel)
+                          </span>
+                          <input
+                            type="text"
+                            value={addressForm.address2 ?? ""}
+                            onChange={(event) =>
+                              handleAddressChange(
+                                "address2",
+                                event.target.value
+                              )
+                            }
+                            className="w-full rounded-sm border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none"
+                          />
+                        </label>
+
+                        <label className="text-sm">
+                          <span className="mb-1 block text-gray-700">
+                            Code postal
+                          </span>
+                          <input
+                            type="text"
+                            value={addressForm.postalCode}
+                            onChange={(event) =>
+                              handleAddressChange(
+                                "postalCode",
+                                event.target.value
+                              )
+                            }
+                            className="w-full rounded-sm border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none"
+                          />
+                        </label>
+
+                        <label className="text-sm">
+                          <span className="mb-1 block text-gray-700">
+                            Ville
+                          </span>
+                          <input
+                            type="text"
+                            value={addressForm.city}
+                            onChange={(event) =>
+                              handleAddressChange(
+                                "city",
+                                event.target.value
+                              )
+                            }
+                            className="w-full rounded-sm border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none"
+                          />
+                        </label>
+
+                        <label className="text-sm">
+                          <span className="mb-1 block text-gray-700">
+                            Région / État (optionnel)
+                          </span>
+                          <input
+                            type="text"
+                            value={addressForm.state ?? ""}
+                            onChange={(event) =>
+                              handleAddressChange(
+                                "state",
+                                event.target.value
+                              )
+                            }
+                            className="w-full rounded-sm border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none"
+                          />
+                        </label>
+
+                        <label className="text-sm">
+                          <span className="mb-1 block text-gray-700">
+                            Pays (code ISO)
+                          </span>
+                          <input
+                            type="text"
+                            value={addressForm.country}
+                            onChange={(event) =>
+                              handleAddressChange(
+                                "country",
+                                event.target.value
+                              )
+                            }
+                            className="w-full rounded-sm border border-gray-300 px-3 py-2 uppercase text-sm focus:border-gray-500 focus:outline-none"
+                            placeholder="FR"
+                          />
+                        </label>
+
+                        <label className="text-sm">
+                          <span className="mb-1 block text-gray-700">
+                            Téléphone (optionnel)
+                          </span>
+                          <input
+                            type="tel"
+                            value={addressForm.phone ?? ""}
+                            onChange={(event) =>
+                              handleAddressChange(
+                                "phone",
+                                event.target.value
+                              )
+                            }
+                            className="w-full rounded-sm border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none"
+                          />
+                        </label>
+
+                        <label className="text-sm">
+                          <span className="mb-1 block text-gray-700">
+                            Email (optionnel)
+                          </span>
+                          <input
+                            type="email"
+                            value={addressForm.email ?? ""}
+                            onChange={(event) =>
+                              handleAddressChange(
+                                "email",
+                                event.target.value
+                              )
+                            }
+                            className="w-full rounded-sm border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none"
+                          />
+                        </label>
+                      </div>
+
+                      <div className="mt-4 flex flex-wrap items-center gap-3">
+                        <button
+                          type="button"
+                          onClick={handleFetchShippingRates}
+                          disabled={isFetchingRates}
+                          className="rounded-sm bg-gray-800 px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {isFetchingRates
+                            ? "Recherche des transporteurs..."
+                            : "Rechercher des transporteurs"}
+                        </button>
+                        {isAddressDirty && (
+                          <span className="text-sm text-amber-600">
+                            L’adresse a changé, relance la recherche pour
+                            actualiser les tarifs.
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="rounded-sm border border-gray-200 p-4 sm:p-6">
+                      <h2 className="text-lg font-semibold text-gray-900">
+                        Transporteurs disponibles
+                      </h2>
+
+                      {shippingError && (
+                        <p className="mt-2 text-sm text-red-600">
+                          {shippingError}
+                        </p>
+                      )}
+
+                      {isFetchingRates ? (
+                        <p className="mt-4 text-sm text-gray-600">
+                          Chargement des tarifs en cours...
+                        </p>
+                      ) : shippingRates.length > 0 ? (
+                        <ul className="mt-4 space-y-3">
+                          {shippingRates.map((rate) => (
+                            <li key={rate.objectId}>
+                              <label className="flex cursor-pointer items-center justify-between gap-4 rounded-sm border border-gray-300 px-3 py-2 text-sm shadow-sm transition hover:border-gray-400">
+                                <div>
+                                  <span className="font-medium text-gray-900">
+                                    {rate.provider} — {rate.serviceLevelName || "Service"}
+                                  </span>
+                                  <span className="mt-1 block text-xs text-gray-600">
+                                    {rate.estimatedDays
+                                      ? `Livraison estimée en ${rate.estimatedDays} jour(s)`
+                                      : rate.durationTerms || "Délai non communiqué"}
+                                  </span>
+                                </div>
+                                <div className="flex items-center gap-3">
+                                  <span className="text-sm font-semibold text-gray-900">
+                                    {formatCurrency(rate.amount, rate.currency)}
+                                  </span>
+                                  <input
+                                    type="radio"
+                                    name="shipping-rate"
+                                    checked={
+                                      selectedShippingRate?.objectId ===
+                                      rate.objectId
+                                    }
+                                    onChange={() =>
+                                      handleSelectShippingRate(rate.objectId)
+                                    }
+                                    className="size-4 accent-gray-800"
+                                  />
+                                </div>
+                              </label>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : selectedShippingRate ? (
+                        <div className="mt-4 rounded-sm border border-dashed border-gray-300 p-4 text-sm text-gray-600">
+                          <p>
+                            Tarif sélectionné :
+                            <span className="ml-1 font-semibold text-gray-900">
+                              {selectedShippingRate.provider} —
+                              {" "}
+                              {selectedShippingRate.serviceLevelName ||
+                                "Service"}
+                              {" "}
+                              ({formatCurrency(
+                                selectedShippingRate.amount,
+                                selectedShippingRate.currency
+                              )})
+                            </span>
+                          </p>
+                          <p className="mt-2 text-xs text-gray-500">
+                            Relance une recherche pour voir d’autres options.
+                          </p>
+                        </div>
+                      ) : (
+                        <p className="mt-4 text-sm text-gray-600">
+                          Renseigne ton adresse puis lance une recherche pour
+                          afficher les transporteurs.
+                        </p>
+                      )}
+                    </div>
                   </div>
 
-                  <dl className="space-y-0.5 text-sm text-gray-700">
-                    <div className="flex justify-between !text-base font-medium">
-                      <dt>Total</dt>
-                      <dd>{total} €</dd>
-                    </div>
-                  </dl>
+                  <div className="space-y-4 rounded-sm border border-gray-200 p-4 sm:p-6">
+                    <h2 className="text-lg font-semibold text-gray-900">
+                      Récapitulatif
+                    </h2>
 
-                  <div className="flex justify-end">
+                    <div className="flex gap-2">
+                      <input
+                        type="text"
+                        placeholder="Code de réduction"
+                        className="w-full rounded-sm border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none"
+                      />
+                      <button className="rounded-sm bg-gray-200 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-300">
+                        Ajouter
+                      </button>
+                    </div>
+
+                    <dl className="space-y-2 text-sm text-gray-700">
+                      <div className="flex justify-between">
+                        <dt>Sous-total</dt>
+                        <dd>{formatCurrency(subtotal, CURRENCY_FALLBACK)}</dd>
+                      </div>
+                      <div className="flex justify-between">
+                        <dt>Livraison</dt>
+                        <dd>
+                          {selectedShippingRate
+                            ? formatCurrency(
+                                selectedShippingRate.amount,
+                                selectedShippingRate.currency
+                              )
+                            : "—"}
+                        </dd>
+                      </div>
+                      <div className="flex justify-between border-t border-dashed border-gray-200 pt-3 text-base font-semibold text-gray-900">
+                        <dt>Total</dt>
+                        <dd>
+                          {formatCurrency(summaryTotal, summaryCurrency)}
+                        </dd>
+                      </div>
+                    </dl>
+
+                    {!selectedShippingRate && (
+                      <p className="text-xs text-red-600">
+                        Sélectionne un transporteur avant de passer au
+                        paiement.
+                      </p>
+                    )}
+
+                    {isAddressDirty && (
+                      <p className="text-xs text-amber-600">
+                        L’adresse a changé, relance la recherche des
+                        transporteurs pour mettre à jour le total.
+                      </p>
+                    )}
+
                     <button
                       onClick={handleCheckout}
-                      className="block rounded-sm bg-gray-700 px-5 py-3 text-sm text-gray-100 transition hover:bg-gray-600"
+                      disabled={
+                        isCreatingCheckout ||
+                        !selectedShippingRate ||
+                        isAddressDirty
+                      }
+                      className="block w-full rounded-sm bg-gray-800 px-5 py-3 text-sm font-medium text-white transition hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-60"
                     >
-                      Checkout
+                      {isCreatingCheckout ? "Redirection..." : "Checkout"}
                     </button>
                   </div>
                 </div>

--- a/app/contexts/CartContext.tsx
+++ b/app/contexts/CartContext.tsx
@@ -10,6 +10,36 @@ export type CartItem = {
   banner?: {
     url: string;
   };
+  weight?: number;
+  length?: number;
+  width?: number;
+  height?: number;
+};
+
+export type ShippingAddress = {
+  fullName?: string;
+  company?: string;
+  address1: string;
+  address2?: string;
+  city: string;
+  state?: string;
+  postalCode: string;
+  country: string;
+  phone?: string;
+  email?: string;
+};
+
+export type ShippingRate = {
+  objectId: string;
+  amount: number;
+  currency: string;
+  provider: string;
+  serviceLevelName: string;
+  serviceLevelToken?: string;
+  estimatedDays?: number | null;
+  durationTerms?: string | null;
+  shipmentId?: string;
+  providerImage75?: string;
 };
 
 export type CartContextType = {
@@ -17,6 +47,10 @@ export type CartContextType = {
   addToCart: (item: CartItem) => void;
   removeFromCart: (id: string | number) => void;
   clearCart: () => void;
+  shippingAddress: ShippingAddress | null;
+  setShippingAddress: (address: ShippingAddress | null) => void;
+  selectedShippingRate: ShippingRate | null;
+  setSelectedShippingRate: (rate: ShippingRate | null) => void;
 };
 
 export const CartContext = createContext<CartContextType | undefined>(
@@ -25,12 +59,38 @@ export const CartContext = createContext<CartContextType | undefined>(
 
 export function CartProvider({ children }: { children: React.ReactNode }) {
   const [cart, setCart] = useState<CartItem[]>([]);
+  const [shippingAddress, setShippingAddressState] =
+    useState<ShippingAddress | null>(null);
+  const [selectedShippingRate, setSelectedShippingRateState] =
+    useState<ShippingRate | null>(null);
 
   useEffect(() => {
     const storedCart = localStorage.getItem("cart");
     if (storedCart) {
       try {
         setCart(JSON.parse(storedCart) as CartItem[]);
+      } catch {
+        // ignore malformed data
+      }
+    }
+
+    const storedShippingAddress = localStorage.getItem("shippingAddress");
+    if (storedShippingAddress) {
+      try {
+        setShippingAddressState(
+          JSON.parse(storedShippingAddress) as ShippingAddress
+        );
+      } catch {
+        // ignore malformed data
+      }
+    }
+
+    const storedShippingRate = localStorage.getItem("shippingRate");
+    if (storedShippingRate) {
+      try {
+        setSelectedShippingRateState(
+          JSON.parse(storedShippingRate) as ShippingRate
+        );
       } catch {
         // ignore malformed data
       }
@@ -55,13 +115,48 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
+  const setShippingAddress = useCallback((address: ShippingAddress | null) => {
+    setShippingAddressState(address);
+
+    if (address) {
+      localStorage.setItem("shippingAddress", JSON.stringify(address));
+    } else {
+      localStorage.removeItem("shippingAddress");
+    }
+  }, []);
+
+  const setSelectedShippingRate = useCallback((rate: ShippingRate | null) => {
+    setSelectedShippingRateState(rate);
+
+    if (rate) {
+      localStorage.setItem("shippingRate", JSON.stringify(rate));
+    } else {
+      localStorage.removeItem("shippingRate");
+    }
+  }, []);
+
   const clearCart = useCallback(() => {
     setCart([]);
+    setShippingAddressState(null);
+    setSelectedShippingRateState(null);
     localStorage.removeItem("cart");
+    localStorage.removeItem("shippingAddress");
+    localStorage.removeItem("shippingRate");
   }, []);
 
   return (
-    <CartContext.Provider value={{ cart, addToCart, removeFromCart, clearCart }}>
+    <CartContext.Provider
+      value={{
+        cart,
+        addToCart,
+        removeFromCart,
+        clearCart,
+        shippingAddress,
+        setShippingAddress,
+        selectedShippingRate,
+        setSelectedShippingRate,
+      }}
+    >
       {children}
     </CartContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add a Shippo-backed API route and cart UI so shoppers can fetch rates and choose a carrier before checkout
- persist shipping address/option in the cart context and include the choice when creating Stripe sessions and orders
- document the Shippo environment variables required to fetch rates locally

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d8e07f508333888a9992add45289