### PR TITLE
Tidy landing layout and copy handling

### DIFF
--- a/app/components/landing/About.tsx
+++ b/app/components/landing/About.tsx
@@ -10,7 +10,7 @@ export default function About() {
             Pourquoi nous choisir ?
           </h2>
           <p className="text-slate-600 max-w-2xl mx-auto">
-            Chez ELEC'CONNECT, nous sommes animés par la vision d'un monde où chaque kilomètre 
+            Chez ELEC&apos;CONNECT, nous sommes animés par la vision d&apos;un monde où chaque kilomètre
             parcouru contribue à un environnement plus propre.
           </p>
         </div>

--- a/app/components/landing/AboutUs.tsx
+++ b/app/components/landing/AboutUs.tsx
@@ -11,21 +11,21 @@ export default function AboutUs() {
           </h2>
           <div className="max-w-4xl mx-auto space-y-6 text-lg text-slate-600 leading-relaxed">
             <p>
-              <strong className="text-emerald-600">ELEC'CONNECT</strong> votre partenaire de confiance pour l'installation professionnelle 
-              de bornes de recharge pour véhicules électriques. Nous nous engageons à fournir des solutions 
+              <strong className="text-emerald-600">ELEC&apos;CONNECT</strong> votre partenaire de confiance pour l&apos;installation professionnelle
+              de bornes de recharge pour véhicules électriques. Nous nous engageons à fournir des solutions
               de recharge efficaces, durables et adaptées à vos besoins.
             </p>
             <p>
-              Chez Elec'connect, nous sommes animés par la vision d'un monde où chaque kilomètre parcouru 
-              est une contribution positive à notre environnement. En faisant le choix de la mobilité électrique, 
-              vous participez activement à la création d'un avenir plus propre et plus durable.
+              Chez Elec&apos;connect, nous sommes animés par la vision d&apos;un monde où chaque kilomètre parcouru
+              est une contribution positive à notre environnement. En faisant le choix de la mobilité électrique,
+              vous participez activement à la création d&apos;un avenir plus propre et plus durable.
             </p>
           </div>
         </div>
 
         <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
-          <div className="text-center group">
-            <div className="w-16 h-16 bg-emerald-100 rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-emerald-200 transition-colors">
+          <div className="text-center">
+            <div className="flex items-center justify-center mx-auto mb-4">
               <Zap className="w-8 h-8 text-emerald-600" />
             </div>
             <h3 className="text-lg font-semibold text-slate-800 mb-2">
@@ -36,8 +36,8 @@ export default function AboutUs() {
             </p>
           </div>
 
-          <div className="text-center group">
-            <div className="w-16 h-16 bg-emerald-100 rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-emerald-200 transition-colors">
+          <div className="text-center">
+            <div className="flex items-center justify-center mx-auto mb-4">
               <Shield className="w-8 h-8 text-emerald-600" />
             </div>
             <h3 className="text-lg font-semibold text-slate-800 mb-2">
@@ -48,8 +48,8 @@ export default function AboutUs() {
             </p>
           </div>
 
-          <div className="text-center group">
-            <div className="w-16 h-16 bg-emerald-100 rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-emerald-200 transition-colors">
+          <div className="text-center">
+            <div className="flex items-center justify-center mx-auto mb-4">
               <Leaf className="w-8 h-8 text-emerald-600" />
             </div>
             <h3 className="text-lg font-semibold text-slate-800 mb-2">
@@ -60,8 +60,8 @@ export default function AboutUs() {
             </p>
           </div>
 
-          <div className="text-center group">
-            <div className="w-16 h-16 bg-emerald-100 rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-emerald-200 transition-colors">
+          <div className="text-center">
+            <div className="flex items-center justify-center mx-auto mb-4">
               <Users className="w-8 h-8 text-emerald-600" />
             </div>
             <h3 className="text-lg font-semibold text-slate-800 mb-2">

--- a/app/components/landing/Contact.tsx
+++ b/app/components/landing/Contact.tsx
@@ -32,7 +32,7 @@ export default function Contact() {
               Contactez-nous
             </h2>
             <p className="text-slate-600 mb-8">
-              Obtenez votre devis gratuit sous 24h pour votre projet d'installation.
+              Obtenez votre devis gratuit sous 24h pour votre projet d&apos;installation.
             </p>
 
             <div className="space-y-4">
@@ -62,7 +62,7 @@ export default function Contact() {
                 </div>
                 <div>
                   <div className="font-medium text-slate-800">Île-de-France</div>
-                  <div className="text-sm text-slate-500">Zone d'intervention</div>
+                  <div className="text-sm text-slate-500">Zone d&apos;intervention</div>
                 </div>
               </div>
             </div>

--- a/app/components/landing/Footer.tsx
+++ b/app/components/landing/Footer.tsx
@@ -9,18 +9,18 @@ export default function Footer() {
           {/* Logo et description */}
           <div className="md:col-span-2 space-y-4">
             <div className="flex items-center space-x-3">
-              <img 
-                src="/image01-high.webp" 
-                alt="ELEC'CONNECT" 
+              <img
+                src="/image01-high.webp"
+                alt="ELEC&apos;CONNECT"
                 className="w-10 h-10 object-contain"
               />
               <div>
-                <h3 className="text-xl font-bold">ELEC'CONNECT</h3>
+                <h3 className="text-xl font-bold">ELEC&apos;CONNECT</h3>
                 <p className="text-emerald-400 text-sm">Solutions de recharge électrique</p>
               </div>
             </div>
             <p className="text-gray-300 leading-relaxed">
-              Votre partenaire de confiance pour l'installation professionnelle de bornes de recharge électrique. 
+              Votre partenaire de confiance pour l&apos;installation professionnelle de bornes de recharge électrique.
               Nous contribuons à un avenir plus durable grâce à la mobilité électrique.
             </p>
             <div className="flex space-x-4">
@@ -69,7 +69,7 @@ export default function Footer() {
 
         <div className="border-t border-gray-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
           <p className="text-gray-400 text-sm">
-            © 2024 ELEC'CONNECT. Tous droits réservés.
+            © 2024 ELEC&apos;CONNECT. Tous droits réservés.
           </p>
           <div className="flex space-x-6 mt-4 md:mt-0">
             <a href="#" className="text-gray-400 hover:text-emerald-400 transition-colors text-sm">

--- a/app/components/landing/Header.tsx
+++ b/app/components/landing/Header.tsx
@@ -1,41 +1,20 @@
 import React from 'react';
-import { Phone, Mail, Menu } from 'lucide-react';
+import { Menu } from 'lucide-react';
 
 export default function Header() {
   return (
     <header className="bg-white shadow-sm sticky top-0 z-50">
-      {/* Top bar with contact info */}
-      <div className="bg-emerald-600 text-white py-2">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center text-sm">
-            <div className="flex space-x-6">
-              <div className="flex items-center space-x-2">
-                <Phone className="w-4 h-4" />
-                <span>+33 1 23 45 67 89</span>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Mail className="w-4 h-4" />
-                <span>contact@elec-connect.fr</span>
-              </div>
-            </div>
-            <div className="hidden sm:block text-xs">
-              Installateur certifié - Devis gratuit sous 24h
-            </div>
-          </div>
-        </div>
-      </div>
-
       {/* Main header */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center space-x-3">
-            <img 
-              src="/image01-high.webp" 
-              alt="ELEC'CONNECT" 
+            <img
+              src="/image01-high.webp"
+              alt="ELEC&apos;CONNECT"
               className="w-12 h-12 object-contain"
             />
             <div>
-              <h1 className="text-2xl font-bold text-gray-900">ELEC'CONNECT</h1>
+              <h1 className="text-2xl font-bold text-gray-900">ELEC&apos;CONNECT</h1>
               <p className="text-sm text-emerald-600 font-medium">Solutions de recharge électrique</p>
             </div>
           </div>

--- a/app/components/landing/Hero.tsx
+++ b/app/components/landing/Hero.tsx
@@ -12,7 +12,7 @@ export default function Hero() {
           </h1>
           
           <p className="text-lg text-slate-600 mb-8 max-w-2xl mx-auto">
-            ELEC'CONNECT, votre partenaire de confiance pour l'installation professionnelle 
+            ELEC&apos;CONNECT, votre partenaire de confiance pour l&apos;installation professionnelle
             de bornes de recharge pour véhicules électriques.
           </p>
 

--- a/app/components/landing/Testimonials.tsx
+++ b/app/components/landing/Testimonials.tsx
@@ -96,7 +96,7 @@ export default function Testimonials() {
                     </div>
 
                     <p className="text-slate-700 mb-6 leading-relaxed text-sm">
-                      "{testimonial.comment}"
+                      &ldquo;{testimonial.comment}&rdquo;
                     </p>
 
                     <div className="flex items-center space-x-3">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,10 +10,11 @@ export default function Page() {
     <div className="min-h-screen">
       <Hero />
       <AboutUs />
+      <About />
       <Testimonials />
       <ProductSection />
-      <About />
       <Contact />
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- remove the green contact strip from the landing header
- move the "Pourquoi nous choisir ?" block directly after "Qui sommes-nous ?" and remove duplicate green icon backdrops
- escape apostrophes within landing content to satisfy linting rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc0120e3f8833390bac4f595900951