### PR TITLE
Adjust landing header and Google reviews styling

### DIFF
--- a/app/components/landing/About.tsx
+++ b/app/components/landing/About.tsx
@@ -10,7 +10,7 @@ export default function About() {
             Pourquoi nous choisir ?
           </h2>
           <p className="text-slate-600 max-w-2xl mx-auto">
-            Chez ELEC'CONNECT, nous sommes animés par la vision d'un monde où chaque kilomètre 
+            Chez ELEC&apos;CONNECT, nous sommes animés par la vision d&apos;un monde où chaque kilomètre
             parcouru contribue à un environnement plus propre.
           </p>
         </div>

--- a/app/components/landing/AboutUs.tsx
+++ b/app/components/landing/AboutUs.tsx
@@ -11,14 +11,14 @@ export default function AboutUs() {
           </h2>
           <div className="max-w-4xl mx-auto space-y-6 text-lg text-slate-600 leading-relaxed">
             <p>
-              <strong className="text-emerald-600">ELEC'CONNECT</strong> votre partenaire de confiance pour l'installation professionnelle 
-              de bornes de recharge pour véhicules électriques. Nous nous engageons à fournir des solutions 
+              <strong className="text-emerald-600">ELEC&apos;CONNECT</strong> votre partenaire de confiance pour l&apos;installation professionnelle
+              de bornes de recharge pour véhicules électriques. Nous nous engageons à fournir des solutions
               de recharge efficaces, durables et adaptées à vos besoins.
             </p>
             <p>
-              Chez Elec'connect, nous sommes animés par la vision d'un monde où chaque kilomètre parcouru 
-              est une contribution positive à notre environnement. En faisant le choix de la mobilité électrique, 
-              vous participez activement à la création d'un avenir plus propre et plus durable.
+              Chez Elec&apos;connect, nous sommes animés par la vision d&apos;un monde où chaque kilomètre parcouru
+              est une contribution positive à notre environnement. En faisant le choix de la mobilité électrique,
+              vous participez activement à la création d&apos;un avenir plus propre et plus durable.
             </p>
           </div>
         </div>

--- a/app/components/landing/Contact.tsx
+++ b/app/components/landing/Contact.tsx
@@ -32,7 +32,7 @@ export default function Contact() {
               Contactez-nous
             </h2>
             <p className="text-slate-600 mb-8">
-              Obtenez votre devis gratuit sous 24h pour votre projet d'installation.
+              Obtenez votre devis gratuit sous 24h pour votre projet d&apos;installation.
             </p>
 
             <div className="space-y-4">
@@ -62,7 +62,7 @@ export default function Contact() {
                 </div>
                 <div>
                   <div className="font-medium text-slate-800">Île-de-France</div>
-                  <div className="text-sm text-slate-500">Zone d'intervention</div>
+                  <div className="text-sm text-slate-500">Zone d&apos;intervention</div>
                 </div>
               </div>
             </div>

--- a/app/components/landing/Footer.tsx
+++ b/app/components/landing/Footer.tsx
@@ -9,18 +9,18 @@ export default function Footer() {
           {/* Logo et description */}
           <div className="md:col-span-2 space-y-4">
             <div className="flex items-center space-x-3">
-              <img 
-                src="/image01-high.webp" 
-                alt="ELEC'CONNECT" 
+              <img
+                src="/image01-high.webp"
+                alt="ELEC&apos;CONNECT"
                 className="w-10 h-10 object-contain"
               />
               <div>
-                <h3 className="text-xl font-bold">ELEC'CONNECT</h3>
+                <h3 className="text-xl font-bold">ELEC&apos;CONNECT</h3>
                 <p className="text-emerald-400 text-sm">Solutions de recharge électrique</p>
               </div>
             </div>
             <p className="text-gray-300 leading-relaxed">
-              Votre partenaire de confiance pour l'installation professionnelle de bornes de recharge électrique. 
+              Votre partenaire de confiance pour l&apos;installation professionnelle de bornes de recharge électrique.
               Nous contribuons à un avenir plus durable grâce à la mobilité électrique.
             </p>
             <div className="flex space-x-4">
@@ -69,7 +69,7 @@ export default function Footer() {
 
         <div className="border-t border-gray-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
           <p className="text-gray-400 text-sm">
-            © 2024 ELEC'CONNECT. Tous droits réservés.
+            © 2024 ELEC&apos;CONNECT. Tous droits réservés.
           </p>
           <div className="flex space-x-6 mt-4 md:mt-0">
             <a href="#" className="text-gray-400 hover:text-emerald-400 transition-colors text-sm">

--- a/app/components/landing/Header.tsx
+++ b/app/components/landing/Header.tsx
@@ -1,41 +1,20 @@
 import React from 'react';
-import { Phone, Mail, Menu } from 'lucide-react';
+import { Menu } from 'lucide-react';
 
 export default function Header() {
   return (
     <header className="bg-white shadow-sm sticky top-0 z-50">
-      {/* Top bar with contact info */}
-      <div className="bg-emerald-600 text-white py-2">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center text-sm">
-            <div className="flex space-x-6">
-              <div className="flex items-center space-x-2">
-                <Phone className="w-4 h-4" />
-                <span>+33 1 23 45 67 89</span>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Mail className="w-4 h-4" />
-                <span>contact@elec-connect.fr</span>
-              </div>
-            </div>
-            <div className="hidden sm:block text-xs">
-              Installateur certifié - Devis gratuit sous 24h
-            </div>
-          </div>
-        </div>
-      </div>
-
       {/* Main header */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center space-x-3">
-            <img 
-              src="/image01-high.webp" 
-              alt="ELEC'CONNECT" 
+            <img
+              src="/image01-high.webp"
+              alt="ELEC&apos;CONNECT"
               className="w-12 h-12 object-contain"
             />
             <div>
-              <h1 className="text-2xl font-bold text-gray-900">ELEC'CONNECT</h1>
+              <h1 className="text-2xl font-bold text-gray-900">ELEC&apos;CONNECT</h1>
               <p className="text-sm text-emerald-600 font-medium">Solutions de recharge électrique</p>
             </div>
           </div>

--- a/app/components/landing/Hero.tsx
+++ b/app/components/landing/Hero.tsx
@@ -12,7 +12,7 @@ export default function Hero() {
           </h1>
           
           <p className="text-lg text-slate-600 mb-8 max-w-2xl mx-auto">
-            ELEC'CONNECT, votre partenaire de confiance pour l'installation professionnelle 
+            ELEC&apos;CONNECT, votre partenaire de confiance pour l&apos;installation professionnelle
             de bornes de recharge pour véhicules électriques.
           </p>
 

--- a/app/components/landing/Testimonials.tsx
+++ b/app/components/landing/Testimonials.tsx
@@ -76,88 +76,78 @@ const GoogleLogo = () => (
 
 export default function Testimonials() {
   return (
-    <section className="bg-gray-50 py-16">
-      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-        <div className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-lg">
-          <div className="grid gap-12 lg:grid-cols-[minmax(0,360px),1fr] lg:items-stretch">
-            {/* Left side - Stats */}
-            <div className="relative isolate flex flex-col justify-between overflow-hidden bg-gradient-to-br from-emerald-50 via-white to-sky-50 p-10">
-              <div className="absolute -right-24 -top-24 h-48 w-48 rounded-full bg-emerald-100/60 blur-2xl" aria-hidden="true" />
-              <div className="relative">
-                <div className="mb-6 flex items-center gap-4">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm ring-1 ring-slate-200">
-                    <GoogleLogo />
-                  </div>
-                  <div>
-                    <p className="text-sm font-semibold text-slate-500">Avis Google</p>
-                    <p className="text-xl font-semibold text-slate-900">Nos clients nous recommandent</p>
-                  </div>
+    <section className="bg-white py-16">
+      <div className="mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-10 lg:flex-row lg:items-stretch">
+          {/* Left side - Rating card */}
+          <div className="mx-auto w-full max-w-md rounded-3xl border border-slate-200 bg-white p-10 shadow-xl lg:mx-0 lg:flex lg:flex-col lg:justify-between">
+            <div>
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white shadow-sm">
+                  <GoogleLogo />
                 </div>
-
-                <h2 className="text-3xl font-bold tracking-tight text-slate-900">Ce que disent nos clients</h2>
-                <p className="mt-4 text-sm text-slate-600">
-                  Une expérience client saluée pour la qualité de nos installations et notre accompagnement sur-mesure.
-                </p>
+                <div className="text-sm font-semibold text-slate-500">Avis Google</div>
               </div>
 
-              <div className="relative mt-10">
-                <div className="flex items-end gap-4">
-                  <span className="text-6xl font-bold text-slate-900">4.9</span>
-                  <div className="flex flex-col gap-2">
-                    <div className="flex items-center space-x-1">
-                      {Array.from({ length: 5 }).map((_, i) => (
-                        <Star key={i} className="h-5 w-5 fill-yellow-400 text-yellow-400" />
-                      ))}
+              <h2 className="mt-6 text-3xl font-bold tracking-tight text-slate-900">Nos clients nous recommandent</h2>
+              <p className="mt-3 text-sm text-slate-600">Ce que disent nos clients.</p>
+            </div>
+
+            <div className="mt-8 border-t border-slate-100 pt-8">
+              <div className="flex items-end gap-4">
+                <span className="text-6xl font-bold text-slate-900">4.9</span>
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center space-x-1">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <Star key={i} className="h-5 w-5 fill-yellow-400 text-yellow-400" />
+                    ))}
+                  </div>
+                  <span className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Note moyenne</span>
+                </div>
+              </div>
+              <p className="mt-3 text-sm text-slate-500">Basée sur plus de 200 avis clients vérifiés.</p>
+            </div>
+          </div>
+
+          {/* Right side - Testimonials Carousel */}
+          <div className="flex-1 rounded-3xl border border-slate-200 bg-white p-6 shadow-lg lg:p-8">
+            <Swiper
+              modules={[Navigation, Pagination, Autoplay]}
+              spaceBetween={24}
+              slidesPerView={1}
+              navigation
+              pagination={{ clickable: true }}
+              autoplay={{
+                delay: 4500,
+                disableOnInteraction: false,
+              }}
+              className="testimonials-swiper"
+            >
+              {testimonials.map((testimonial) => (
+                <SwiperSlide key={testimonial.id}>
+                  <article className="flex h-full flex-col justify-between rounded-2xl border border-slate-100 bg-slate-50 p-6 shadow-sm">
+                    <div>
+                      <div className="mb-3 flex space-x-1">
+                        {Array.from({ length: testimonial.rating }).map((_, i) => (
+                          <Star key={i} className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                        ))}
+                      </div>
+                      <p className="text-sm leading-relaxed text-slate-600">&ldquo;{testimonial.comment}&rdquo;</p>
                     </div>
-                    <span className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Satisfaction globale</span>
-                  </div>
-                </div>
-                <p className="mt-3 text-sm text-slate-500">
-                  Note moyenne basée sur plus de 200 avis clients vérifiés.
-                </p>
-              </div>
-            </div>
 
-            {/* Right side - Testimonials Carousel */}
-            <div className="border-t border-slate-100 bg-slate-50/40 p-6 lg:border-l lg:border-t-0 lg:p-10">
-              <Swiper
-                modules={[Navigation, Pagination, Autoplay]}
-                spaceBetween={24}
-                slidesPerView={1}
-                navigation
-                pagination={{ clickable: true }}
-                autoplay={{
-                  delay: 4500,
-                  disableOnInteraction: false,
-                }}
-                className="testimonials-swiper"
-              >
-                {testimonials.map((testimonial) => (
-                  <SwiperSlide key={testimonial.id}>
-                    <article className="flex h-full flex-col justify-between rounded-2xl border border-slate-200/80 bg-white/90 p-8 shadow-sm backdrop-blur">
+                    <div className="mt-6 flex items-center gap-4">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-600">
+                        <span className="text-sm font-medium text-white">{testimonial.avatar}</span>
+                      </div>
                       <div>
-                        <div className="mb-4 flex space-x-1">
-                          {Array.from({ length: testimonial.rating }).map((_, i) => (
-                            <Star key={i} className="h-4 w-4 fill-yellow-400 text-yellow-400" />
-                          ))}
-                        </div>
-                        <p className="text-base leading-relaxed text-slate-600">&ldquo;{testimonial.comment}&rdquo;</p>
+                        <div className="text-sm font-semibold text-slate-900">{testimonial.name}</div>
+                        <div className="text-xs text-slate-500">{testimonial.role} • {testimonial.location}</div>
                       </div>
-
-                      <div className="mt-8 flex items-center gap-4">
-                        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-600">
-                          <span className="text-sm font-medium text-white">{testimonial.avatar}</span>
-                        </div>
-                        <div>
-                          <div className="text-sm font-semibold text-slate-900">{testimonial.name}</div>
-                          <div className="text-xs text-slate-500">{testimonial.role} • {testimonial.location}</div>
-                        </div>
-                      </div>
-                    </article>
-                  </SwiperSlide>
-                ))}
-              </Swiper>
-            </div>
+                    </div>
+                  </article>
+                </SwiperSlide>
+              ))}
+            </Swiper>
           </div>
         </div>
       </div>

--- a/app/components/landing/Testimonials.tsx
+++ b/app/components/landing/Testimonials.tsx
@@ -76,72 +76,88 @@ const GoogleLogo = () => (
 
 export default function Testimonials() {
   return (
-    <section className="py-16 bg-gray-50">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="grid gap-10 lg:grid-cols-[320px,1fr] lg:items-center">
-          {/* Left side - Stats */}
-          <div className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
-            <div className="mb-6 flex items-center gap-3">
-              <GoogleLogo />
-              <div>
-                <p className="text-sm font-medium text-slate-500">Avis Google</p>
-                <p className="text-lg font-semibold text-slate-900">Nos clients nous recommandent</p>
-              </div>
-            </div>
-
-            <h2 className="text-3xl font-bold text-slate-900">Ce que disent nos clients</h2>
-
-            <div className="mt-6">
-              <div className="flex items-baseline gap-3">
-                <span className="text-5xl font-bold text-slate-900">4.9</span>
-                <div className="flex space-x-1">
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <Star key={i} className="h-5 w-5 fill-yellow-400 text-yellow-400" />
-                  ))}
+    <section className="bg-gray-50 py-16">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-lg">
+          <div className="grid gap-12 lg:grid-cols-[minmax(0,360px),1fr] lg:items-stretch">
+            {/* Left side - Stats */}
+            <div className="relative isolate flex flex-col justify-between overflow-hidden bg-gradient-to-br from-emerald-50 via-white to-sky-50 p-10">
+              <div className="absolute -right-24 -top-24 h-48 w-48 rounded-full bg-emerald-100/60 blur-2xl" aria-hidden="true" />
+              <div className="relative">
+                <div className="mb-6 flex items-center gap-4">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm ring-1 ring-slate-200">
+                    <GoogleLogo />
+                  </div>
+                  <div>
+                    <p className="text-sm font-semibold text-slate-500">Avis Google</p>
+                    <p className="text-xl font-semibold text-slate-900">Nos clients nous recommandent</p>
+                  </div>
                 </div>
-              </div>
-              <p className="mt-3 text-sm text-slate-500">Note moyenne basée sur plus de 200 avis clients.</p>
-            </div>
-          </div>
 
-          {/* Right side - Testimonials Carousel */}
-          <div className="relative">
-            <Swiper
-              modules={[Navigation, Pagination, Autoplay]}
-              spaceBetween={16}
-              slidesPerView={1}
-              navigation
-              pagination={{ clickable: true }}
-              autoplay={{
-                delay: 4000,
-                disableOnInteraction: false,
-              }}
-              className="testimonials-swiper"
-            >
-              {testimonials.map((testimonial) => (
-                <SwiperSlide key={testimonial.id}>
-                  <div className="mx-auto max-w-sm rounded-2xl border border-slate-200 bg-white p-6 shadow-md">
-                    <div className="mb-4 flex space-x-1">
-                      {Array.from({ length: testimonial.rating }).map((_, i) => (
-                        <Star key={i} className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                <h2 className="text-3xl font-bold tracking-tight text-slate-900">Ce que disent nos clients</h2>
+                <p className="mt-4 text-sm text-slate-600">
+                  Une expérience client saluée pour la qualité de nos installations et notre accompagnement sur-mesure.
+                </p>
+              </div>
+
+              <div className="relative mt-10">
+                <div className="flex items-end gap-4">
+                  <span className="text-6xl font-bold text-slate-900">4.9</span>
+                  <div className="flex flex-col gap-2">
+                    <div className="flex items-center space-x-1">
+                      {Array.from({ length: 5 }).map((_, i) => (
+                        <Star key={i} className="h-5 w-5 fill-yellow-400 text-yellow-400" />
                       ))}
                     </div>
-
-                    <p className="mb-6 text-sm leading-relaxed text-slate-600">&ldquo;{testimonial.comment}&rdquo;</p>
-
-                    <div className="flex items-center gap-3">
-                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-600">
-                        <span className="text-sm font-medium text-white">{testimonial.avatar}</span>
-                      </div>
-                      <div>
-                        <div className="text-sm font-medium text-slate-900">{testimonial.name}</div>
-                        <div className="text-xs text-slate-500">{testimonial.role} - {testimonial.location}</div>
-                      </div>
-                    </div>
+                    <span className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Satisfaction globale</span>
                   </div>
-                </SwiperSlide>
-              ))}
-            </Swiper>
+                </div>
+                <p className="mt-3 text-sm text-slate-500">
+                  Note moyenne basée sur plus de 200 avis clients vérifiés.
+                </p>
+              </div>
+            </div>
+
+            {/* Right side - Testimonials Carousel */}
+            <div className="border-t border-slate-100 bg-slate-50/40 p-6 lg:border-l lg:border-t-0 lg:p-10">
+              <Swiper
+                modules={[Navigation, Pagination, Autoplay]}
+                spaceBetween={24}
+                slidesPerView={1}
+                navigation
+                pagination={{ clickable: true }}
+                autoplay={{
+                  delay: 4500,
+                  disableOnInteraction: false,
+                }}
+                className="testimonials-swiper"
+              >
+                {testimonials.map((testimonial) => (
+                  <SwiperSlide key={testimonial.id}>
+                    <article className="flex h-full flex-col justify-between rounded-2xl border border-slate-200/80 bg-white/90 p-8 shadow-sm backdrop-blur">
+                      <div>
+                        <div className="mb-4 flex space-x-1">
+                          {Array.from({ length: testimonial.rating }).map((_, i) => (
+                            <Star key={i} className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                          ))}
+                        </div>
+                        <p className="text-base leading-relaxed text-slate-600">&ldquo;{testimonial.comment}&rdquo;</p>
+                      </div>
+
+                      <div className="mt-8 flex items-center gap-4">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-600">
+                          <span className="text-sm font-medium text-white">{testimonial.avatar}</span>
+                        </div>
+                        <div>
+                          <div className="text-sm font-semibold text-slate-900">{testimonial.name}</div>
+                          <div className="text-xs text-slate-500">{testimonial.role} • {testimonial.location}</div>
+                        </div>
+                      </div>
+                    </article>
+                  </SwiperSlide>
+                ))}
+              </Swiper>
+            </div>
           </div>
         </div>
       </div>

--- a/app/components/landing/Testimonials.tsx
+++ b/app/components/landing/Testimonials.tsx
@@ -47,28 +47,60 @@ const testimonials = [
   }
 ];
 
+const GoogleLogo = () => (
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    className="h-8 w-8"
+    viewBox="0 0 256 262"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fill="#4285F4"
+      d="M255.68 131.14c0-10.89-.95-21.35-2.75-31.34H130.98v59.42h69.74a59.6 59.6 0 0 1-25.89 39.14l-.24 1.62 37.56 29.1 2.6.26c23.88-22 37.93-54.42 37.93-98.2"
+    />
+    <path
+      fill="#34A853"
+      d="M130.98 261.1c34.41 0 63.32-11.37 84.43-30.78l-40.2-31.16c-10.8 7.42-24.69 12.6-44.23 12.6-33.85 0-62.57-22.72-72.83-54.06l-1.5.12-39.34 30.45-.52 1.47c20.89 41.54 64.13 71.36 114.19 71.36"
+    />
+    <path
+      fill="#FBBC05"
+      d="M58.15 157.69a78.3 78.3 0 0 1-4.1-25.09c0-8.75 1.47-17.2 3.95-25.09l-.07-1.68-39.82-30.96-1.3.62A130.92 130.92 0 0 0 .39 132.6c0 20.96 5.02 40.76 14 58.22l43.76-33.13"
+    />
+    <path
+      fill="#EA4335"
+      d="M130.98 49.64c23.95 0 40.06 10.34 49.27 19.01l35.94-35.08C194.2 12.03 165.39.9 130.98.9 80.92.9 37.68 30.72 16.79 72.26l43.76 33.12c10.26-31.33 38.98-55.74 70.43-55.74"
+    />
+  </svg>
+);
+
 export default function Testimonials() {
   return (
-    <section className="py-20 bg-slate-600">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="grid lg:grid-cols-2 gap-16 items-center">
+    <section className="py-16 bg-gray-50">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid gap-10 lg:grid-cols-[320px,1fr] lg:items-center">
           {/* Left side - Stats */}
-          <div className="text-white">
-            <h2 className="text-4xl font-bold mb-6">
-              Ce que disent nos clients
-            </h2>
-            
-            <div className="mb-8">
-              <div className="text-5xl font-bold mb-3">4.9</div>
-              <div className="text-slate-300 text-lg mb-3">Note moyenne</div>
-              <div className="flex space-x-1 mb-4">
-                {Array.from({ length: 5 }).map((_, i) => (
-                  <Star key={i} className="w-5 h-5 text-yellow-400 fill-current" />
-                ))}
+          <div className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
+            <div className="mb-6 flex items-center gap-3">
+              <GoogleLogo />
+              <div>
+                <p className="text-sm font-medium text-slate-500">Avis Google</p>
+                <p className="text-lg font-semibold text-slate-900">Nos clients nous recommandent</p>
               </div>
-              <div className="text-slate-300">
-                Basé sur plus de 200 avis clients
+            </div>
+
+            <h2 className="text-3xl font-bold text-slate-900">Ce que disent nos clients</h2>
+
+            <div className="mt-6">
+              <div className="flex items-baseline gap-3">
+                <span className="text-5xl font-bold text-slate-900">4.9</span>
+                <div className="flex space-x-1">
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <Star key={i} className="h-5 w-5 fill-yellow-400 text-yellow-400" />
+                  ))}
+                </div>
               </div>
+              <p className="mt-3 text-sm text-slate-500">Note moyenne basée sur plus de 200 avis clients.</p>
             </div>
           </div>
 
@@ -76,7 +108,7 @@ export default function Testimonials() {
           <div className="relative">
             <Swiper
               modules={[Navigation, Pagination, Autoplay]}
-              spaceBetween={20}
+              spaceBetween={16}
               slidesPerView={1}
               navigation
               pagination={{ clickable: true }}
@@ -88,23 +120,21 @@ export default function Testimonials() {
             >
               {testimonials.map((testimonial) => (
                 <SwiperSlide key={testimonial.id}>
-                  <div className="bg-white rounded-xl p-6 shadow-lg">
-                    <div className="flex space-x-1 mb-4">
+                  <div className="mx-auto max-w-sm rounded-2xl border border-slate-200 bg-white p-6 shadow-md">
+                    <div className="mb-4 flex space-x-1">
                       {Array.from({ length: testimonial.rating }).map((_, i) => (
-                        <Star key={i} className="w-4 h-4 text-yellow-400 fill-current" />
+                        <Star key={i} className="h-4 w-4 fill-yellow-400 text-yellow-400" />
                       ))}
                     </div>
 
-                    <p className="text-slate-700 mb-6 leading-relaxed text-sm">
-                      "{testimonial.comment}"
-                    </p>
+                    <p className="mb-6 text-sm leading-relaxed text-slate-600">&ldquo;{testimonial.comment}&rdquo;</p>
 
-                    <div className="flex items-center space-x-3">
-                      <div className="w-10 h-10 bg-emerald-600 rounded-full flex items-center justify-center">
-                        <span className="text-white text-sm font-medium">{testimonial.avatar}</span>
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-600">
+                        <span className="text-sm font-medium text-white">{testimonial.avatar}</span>
                       </div>
                       <div>
-                        <div className="font-medium text-slate-800 text-sm">{testimonial.name}</div>
+                        <div className="text-sm font-medium text-slate-900">{testimonial.name}</div>
                         <div className="text-xs text-slate-500">{testimonial.role} - {testimonial.location}</div>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- remove the green contact ribbon from the landing header to keep the navigation compact
- redesign the Google reviews section with a white card layout, Google branding, and tighter testimonial cards
- escape apostrophes in landing copy to satisfy linting rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc0830618483338e1c1972ec9c869f