### PR TITLE
Add gradient halo effect to AboutUs section

### DIFF
--- a/app/components/landing/About.tsx
+++ b/app/components/landing/About.tsx
@@ -10,7 +10,7 @@ export default function About() {
             Pourquoi nous choisir ?
           </h2>
           <p className="text-slate-600 max-w-2xl mx-auto">
-            Chez ELEC'CONNECT, nous sommes animés par la vision d'un monde où chaque kilomètre 
+            Chez ELEC&apos;CONNECT, nous sommes animés par la vision d&apos;un monde où chaque kilomètre
             parcouru contribue à un environnement plus propre.
           </p>
         </div>

--- a/app/components/landing/AboutUs.tsx
+++ b/app/components/landing/AboutUs.tsx
@@ -6,8 +6,11 @@ import { Zap, Shield, Leaf, Users } from "lucide-react";
 
 export default function AboutUs() {
   return (
-    <section className="py-20 bg-white">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section className="relative py-20 bg-white overflow-hidden">
+      {/* Effets de halo lumineux venant des côtés */}
+      <div className="pointer-events-none absolute inset-y-0 left-0 w-1/2 max-w-lg -z-10 bg-gradient-to-r from-slate-300/70 via-slate-100/30 to-transparent blur-3xl" />
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-1/2 max-w-lg -z-10 bg-gradient-to-l from-slate-300/70 via-slate-100/30 to-transparent blur-3xl" />
+      <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Titre */}
         <div className="text-center mb-10">
           <h2 className="text-4xl font-bold text-slate-800">
@@ -21,7 +24,7 @@ export default function AboutUs() {
           <div className="max-w-2xl">
             <div className="space-y-5 text-lg text-slate-700 leading-relaxed">
               <p>
-                <strong className="text-emerald-600">ELEC'CONNECT</strong> est
+                <strong className="text-emerald-600">ELEC&apos;CONNECT</strong> est
                 votre partenaire de confiance pour l’installation professionnelle
                 de bornes de recharge pour véhicules électriques. Nous proposons
                 des solutions de recharge efficaces, durables et adaptées à vos usages.
@@ -38,7 +41,7 @@ export default function AboutUs() {
           <div className="relative w-full h-56 sm:h-64 lg:h-72">
             <Image
               src="/borne.png"
-              alt="Borne de recharge ELEC'CONNECT"
+              alt="Borne de recharge ELEC&apos;CONNECT"
               fill
               sizes="(max-width: 1024px) 100vw, 600px"
               className="object-contain" // pas de card/ombre/arrondis

--- a/app/components/landing/Contact.tsx
+++ b/app/components/landing/Contact.tsx
@@ -32,7 +32,7 @@ export default function Contact() {
               Contactez-nous
             </h2>
             <p className="text-slate-600 mb-8">
-              Obtenez votre devis gratuit sous 24h pour votre projet d'installation.
+              Obtenez votre devis gratuit sous 24h pour votre projet d&apos;installation.
             </p>
 
             <div className="space-y-4">
@@ -62,7 +62,7 @@ export default function Contact() {
                 </div>
                 <div>
                   <div className="font-medium text-slate-800">Île-de-France</div>
-                  <div className="text-sm text-slate-500">Zone d'intervention</div>
+                  <div className="text-sm text-slate-500">Zone d&apos;intervention</div>
                 </div>
               </div>
             </div>

--- a/app/components/landing/Footer.tsx
+++ b/app/components/landing/Footer.tsx
@@ -9,18 +9,18 @@ export default function Footer() {
           {/* Logo et description */}
           <div className="md:col-span-2 space-y-4">
             <div className="flex items-center space-x-3">
-              <img 
-                src="/image01-high.webp" 
-                alt="ELEC'CONNECT" 
+              <img
+                src="/image01-high.webp"
+                alt="ELEC&apos;CONNECT"
                 className="w-10 h-10 object-contain"
               />
               <div>
-                <h3 className="text-xl font-bold">ELEC'CONNECT</h3>
+                <h3 className="text-xl font-bold">ELEC&apos;CONNECT</h3>
                 <p className="text-emerald-400 text-sm">Solutions de recharge électrique</p>
               </div>
             </div>
             <p className="text-gray-300 leading-relaxed">
-              Votre partenaire de confiance pour l'installation professionnelle de bornes de recharge électrique. 
+              Votre partenaire de confiance pour l&apos;installation professionnelle de bornes de recharge électrique.
               Nous contribuons à un avenir plus durable grâce à la mobilité électrique.
             </p>
             <div className="flex space-x-4">
@@ -69,7 +69,7 @@ export default function Footer() {
 
         <div className="border-t border-gray-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
           <p className="text-gray-400 text-sm">
-            © 2024 ELEC'CONNECT. Tous droits réservés.
+            © 2024 ELEC&apos;CONNECT. Tous droits réservés.
           </p>
           <div className="flex space-x-6 mt-4 md:mt-0">
             <a href="#" className="text-gray-400 hover:text-emerald-400 transition-colors text-sm">

--- a/app/components/landing/Header.tsx
+++ b/app/components/landing/Header.tsx
@@ -9,12 +9,12 @@ export default function Header() {
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center space-x-3">
             <img
-              src="/image01-high.webp" 
-              alt="ELEC'CONNECT" 
+              src="/image01-high.webp"
+              alt="ELEC&apos;CONNECT"
               className="w-12 h-12 object-contain"
             />
             <div>
-              <h1 className="text-2xl font-bold text-gray-900">ELEC'CONNECT</h1>
+              <h1 className="text-2xl font-bold text-gray-900">ELEC&apos;CONNECT</h1>
               <p className="text-sm text-emerald-600 font-medium">Solutions de recharge électrique</p>
             </div>
           </div>

--- a/app/components/landing/Hero.tsx
+++ b/app/components/landing/Hero.tsx
@@ -14,7 +14,7 @@ export default function Hero() {
           </h1>
           
           <p className="text-lg text-slate-600 mb-8 max-w-2xl mx-auto">
-            ELEC'CONNECT, votre partenaire de confiance pour l'installation professionnelle 
+            ELEC&apos;CONNECT, votre partenaire de confiance pour l&apos;installation professionnelle
             de bornes de recharge pour véhicules électriques.
           </p>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,6 @@ import Hero from "./components/landing/Hero";
 import AboutUs from "./components/landing/AboutUs";
 import Testimonials from "./components/landing/Testimonials";
 import ProductSection from "./components/landing/ProductSection";
-import About from "./components/landing/About";
 import Contact from "./components/landing/Contact";
 
 export default function Page() {


### PR DESCRIPTION
## Summary
- add decorative grey gradient halos on the sides of the AboutUs section to create a shiny ambiance
- ensure the main content stays above the gradients by updating layout z-index handling
- escape apostrophes in landing components and remove an unused import to satisfy lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc74c277e4833385e0d2c2176f93d2