### PR TITLE
Adjust shop pagination to six products per page

### DIFF
--- a/app/shop/page.tsx
+++ b/app/shop/page.tsx
@@ -23,7 +23,7 @@ interface PaginationMeta {
   total: number;
 }
 
-const PAGE_SIZE = 4;
+const PAGE_SIZE = 6;
 const IMAGE_FALLBACK = "/borne2.png";
 
 export default function ShopPage() {
@@ -118,7 +118,7 @@ export default function ShopPage() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mb-10">
           <h1 className="text-4xl font-extrabold text-slate-900 tracking-tight">Boutique</h1>
-          <p className="text-slate-600 mt-1">Découvrez nos produits. 4 par page.</p>
+          <p className="text-slate-600 mt-1">Découvrez nos produits. 6 par page.</p>
         </div>
 
         {loading ? (


### PR DESCRIPTION
## Summary
- increase the shop page size constant so each page fetches six products
- update the shop description text to reflect the new pagination size

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0aa7eb348333b77ab8e83f6c1f1b