### PR TITLE
Use internal API for landing products

### DIFF
--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -11,12 +11,24 @@ type ProductsResponse = {
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const rawPage = searchParams.get("page");
-  const parsedPage = rawPage ? Number.parseInt(rawPage, 10) : NaN;
-  const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
-
   try {
-    const res = await productApis.getProductsPagination({ page, pageSize: PAGE_SIZE });
+    const rawPage = searchParams.get("page");
+    const hasPageParam = rawPage !== null;
+
+    if (hasPageParam) {
+      const parsedPage = Number.parseInt(rawPage ?? "", 10);
+      const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+
+      const res = await productApis.getProductsPagination({ page, pageSize: PAGE_SIZE });
+      const payload: ProductsResponse = res?.data ?? {};
+
+      return NextResponse.json({
+        data: payload.data ?? [],
+        meta: payload.meta ?? null,
+      });
+    }
+
+    const res = await productApis.getProducts();
     const payload: ProductsResponse = res?.data ?? {};
 
     return NextResponse.json({


### PR DESCRIPTION
## Summary
- update the `/api/products` route to call Strapi through `getProducts` when no pagination is requested
- update the landing `ProductSection` carousel to fetch products through the internal API and normalise the product fields for display

## Testing
- npm run lint *(fails: existing lint issues in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d05d3600d483339d2fa8ba592412f8