### PR TITLE
Close cart popover when continuing shopping

### DIFF
--- a/app/components/landing/Header.tsx
+++ b/app/components/landing/Header.tsx
@@ -181,7 +181,7 @@ export default function Header() {
       )}
 
       {/* Popover Panier */}
-      {openCart && <Cart />}
+      {openCart && <Cart onClose={() => setOpenCart(false)} />}
     </header>
   );
 }

--- a/app/components/ui/Cart.tsx
+++ b/app/components/ui/Cart.tsx
@@ -89,7 +89,7 @@ function CartEmptyState() {
 }
 
 // --- Main Cart ---
-function Cart() {
+function Cart({ onClose }: { onClose?: () => void }) {
   const { cart, removeFromCart } = useContext(CartContext) as CartContextType;
 
   // Logique de regroupement comme dans ton deuxième composant
@@ -181,12 +181,13 @@ function Cart() {
               )}
             </a>
 
-            <a 
-              href="/shop" 
+            <button
+              type="button"
+              onClick={onClose}
               className="block w-full text-center text-sm text-gray-600 hover:text-emerald-700 font-medium py-2.5 px-4 rounded-lg border border-gray-200 hover:border-emerald-200 bg-white transition-colors"
             >
               Continuer mes achats
-            </a>
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- allow the cart popover component to receive an optional onClose callback
- turn the "Continuer mes achats" control into a button that triggers the close handler
- pass the close handler from the header so continuing shopping just dismisses the cart overlay

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d19663463883339853b370c420dfbc