### PR TITLE
Revamp success page design

### DIFF
--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -4,6 +4,16 @@ import { useContext, useEffect, useState } from "react";
 import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import {
+  ArrowRight,
+  CheckCircle2,
+  Home,
+  Mail,
+  MapPin,
+  Phone,
+  Receipt,
+  Truck,
+} from "lucide-react";
 import { CartContext, CartContextType } from "../contexts/CartContext";
 
 interface Address {
@@ -91,143 +101,259 @@ function SuccessPage() {
     if (user && cart.length > 0) {
       createOrder();
     }
-  }, [cart, clearCart, user]);
-  
-  useEffect(() => {
-    console.log(order);
-  }, [order]);
+  }, [cart, clearCart, router, user]);
 
   if (isLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-white via-slate-50 to-emerald-50/30">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <div className="h-14 w-14 rounded-full border-4 border-emerald-500/40 border-t-emerald-500 animate-spin" />
+          <div>
+            <p className="text-lg font-semibold text-slate-800">Validation de votre commande…</p>
+            <p className="text-sm text-slate-500">Merci de patienter pendant que nous finalisons les détails.</p>
+          </div>
+        </div>
       </div>
     );
   }
 
   if (!order) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center p-8 text-center">
-        <div className="bg-white p-8 rounded-lg shadow-lg max-w-2xl w-full">
-          <h2 className="text-2xl font-bold text-gray-800 mb-4">Commande non trouvée</h2>
-          <p className="text-gray-600 mb-6">Nous n'avons pas pu récupérer les détails de votre commande.</p>
-          <Link href="/" className="inline-block bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 transition-colors">
-            Retour à l'accueil
-          </Link>
+      <section className="min-h-screen flex items-center justify-center bg-gradient-to-b from-white via-slate-50 to-emerald-50/30 px-4 py-16">
+        <div className="max-w-xl w-full bg-white/90 backdrop-blur rounded-3xl border border-slate-200 shadow-xl p-10 text-center">
+          <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-emerald-50">
+            <Receipt className="h-10 w-10 text-emerald-600" />
+          </div>
+          <h2 className="text-3xl font-bold text-slate-900">Commande introuvable</h2>
+          <p className="mt-3 text-base text-slate-600">
+            Nous n’avons pas pu récupérer les détails de votre commande. Notre équipe est à votre écoute pour vous aider.
+          </p>
+          <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center gap-2 rounded-full bg-emerald-600 px-6 py-3 text-white shadow-lg shadow-emerald-600/20 transition-all hover:-translate-y-0.5 hover:bg-emerald-700"
+            >
+              <Home className="h-4 w-4" />
+              Retour à l’accueil
+            </Link>
+            <a
+              href="mailto:contact@elecconnect.com"
+              className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 px-6 py-3 text-slate-700 transition-all hover:-translate-y-0.5 hover:border-emerald-200 hover:bg-emerald-50/60"
+            >
+              <Mail className="h-4 w-4" />
+              Nous contacter
+            </a>
+          </div>
         </div>
-      </div>
+      </section>
     );
   }
 
-  const orderDate = new Date(order.createdAt).toLocaleDateString('fr-FR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit'
+  const orderDate = new Date(order.createdAt).toLocaleDateString("fr-FR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
   });
 
   return (
-    <section className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-4xl mx-auto">
-        <div className="bg-white rounded-lg shadow-md overflow-hidden">
-          {/* En-tête */}
-          <div className="bg-green-50 px-6 py-8 text-center border-b border-green-100">
-            <div className="w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg
-                className="w-10 h-10 text-green-600"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M5 13l4 4L19 7"
-                />
-              </svg>
-            </div>
-            <h1 className="text-3xl font-bold text-green-800 mb-2">Commande confirmée !</h1>
-            <p className="text-green-600 text-lg mb-2">Merci pour votre commande !</p>
-            <p className="text-gray-600">Un email de confirmation vous a été envoyé à {user?.emailAddresses?.[0]?.emailAddress}</p>
+    <section className="relative min-h-screen bg-gradient-to-b from-white via-slate-50 to-emerald-50/20 px-4 py-16 sm:px-8">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-12 text-center">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100 shadow-inner shadow-emerald-200">
+            <CheckCircle2 className="h-8 w-8 text-emerald-600" />
           </div>
+          <h1 className="mt-6 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+            Merci pour votre confiance !
+          </h1>
+          <p className="mt-3 text-lg text-slate-600">
+            Votre commande est confirmée. Un récapitulatif vient d’être envoyé à <span className="font-semibold text-slate-800">{user?.emailAddresses?.[0]?.emailAddress}</span>.
+          </p>
+        </div>
 
-          {/* Détails de la commande */}
-          <div className="p-6 md:p-8">
-            <div className="mb-8">
-              <h2 className="text-xl font-semibold text-gray-800 mb-4">Récapitulatif de la commande</h2>
-              <div className="bg-gray-50 p-4 rounded-lg">
-                <div className="flex justify-between mb-2">
-                  <span className="text-gray-600">N° de commande</span>
-                  <span className="font-medium">{order.orderNumber}</span>
+        <div className="grid gap-8 lg:grid-cols-[1.4fr_1fr]">
+          <div className="overflow-hidden rounded-3xl border border-emerald-100/60 bg-white shadow-xl shadow-emerald-600/5">
+            <div className="bg-gradient-to-r from-emerald-600 to-emerald-500 px-6 py-8 text-white sm:px-10">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                  <p className="text-sm uppercase tracking-[0.35em] text-emerald-100/90">Commande #{order.orderNumber}</p>
+                  <h2 className="mt-2 text-3xl font-semibold">Confirmation enregistrée</h2>
+                  <p className="mt-2 text-emerald-100">
+                    Passée le {orderDate}
+                  </p>
                 </div>
-                <div className="flex justify-between mb-2">
-                  <span className="text-gray-600">Date</span>
-                  <span>{orderDate}</span>
-                </div>
-                {order.orderStatus !== 'pending' && (
-                  <div className="flex justify-between mb-2">
-                    <span className="text-gray-600">Statut</span>
-                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                      {order.orderStatus}
-                    </span>
+                {order.orderStatus !== "pending" && (
+                  <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-sm font-medium">
+                    <span className="inline-flex h-2 w-2 rounded-full bg-emerald-300" aria-hidden />
+                    {order.orderStatus}
                   </div>
                 )}
               </div>
             </div>
 
-            {/* Adresse de livraison */}
-            {order.address && (
-              <div className="mb-8">
-                <h3 className="text-lg font-medium text-gray-900 mb-3">Adresse de livraison</h3>
-                <div className="bg-gray-50 p-4 rounded-lg">
-                  <p className="font-medium">{order.address.fullName}</p>
-                  {order.address.company && <p>{order.address.company}</p>}
-                  <p>{order.address.address1}</p>
-                  {order.address.address2 && <p>{order.address.address2}</p>}
-                  <p>{order.address.postalCode} {order.address.city}</p>
-                  <p>{order.address.country}</p>
-                  {order.address.phone && <p className="mt-2">Tél: {order.address.phone}</p>}
+            <div className="space-y-10 px-6 py-8 sm:px-10">
+              <div className="grid gap-6 sm:grid-cols-2">
+                <div className="rounded-2xl border border-slate-100 bg-slate-50/60 p-6">
+                  <div className="mb-4 flex items-center gap-3 text-slate-700">
+                    <Receipt className="h-5 w-5 text-emerald-500" />
+                    <span className="text-sm font-semibold uppercase tracking-wide">Informations commande</span>
+                  </div>
+                  <dl className="space-y-3 text-sm text-slate-600">
+                    <div className="flex justify-between">
+                      <dt>Numéro</dt>
+                      <dd className="font-medium text-slate-900">{order.orderNumber}</dd>
+                    </div>
+                    <div className="flex justify-between">
+                      <dt>Date</dt>
+                      <dd>{orderDate}</dd>
+                    </div>
+                    {order.orderStatus !== "pending" && (
+                      <div className="flex justify-between">
+                        <dt>Statut</dt>
+                        <dd className="inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+                          <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
+                          {order.orderStatus}
+                        </dd>
+                      </div>
+                    )}
+                  </dl>
                 </div>
-              </div>
-            )}
 
-            {/* Livraison */}
-            {order.shipping && (
-              <div className="mb-8">
-                <h3 className="text-lg font-medium text-gray-900 mb-3">Livraison</h3>
-                <div className="bg-gray-50 p-4 rounded-lg">
-                  <p className="font-medium">{order.shipping.carrier || 'Livraison standard'}</p>
-                  <p>Frais de port: {order.shipping.price ? `${order.shipping.price.toFixed(2)} €` : 'Offerts'}</p>
+                {order.shipping && (
+                  <div className="rounded-2xl border border-slate-100 bg-slate-50/60 p-6">
+                    <div className="mb-4 flex items-center gap-3 text-slate-700">
+                      <Truck className="h-5 w-5 text-emerald-500" />
+                      <span className="text-sm font-semibold uppercase tracking-wide">Livraison</span>
+                    </div>
+                    <p className="text-sm text-slate-600">
+                      Transporteur : <span className="font-medium text-slate-900">{order.shipping.carrier || "Livraison standard"}</span>
+                    </p>
+                    <p className="mt-2 text-sm text-slate-600">
+                      Frais de port : <span className="font-medium text-slate-900">{order.shipping.price ? `${order.shipping.price.toFixed(2)} €` : "Offerts"}</span>
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {order.address && (
+                <div className="rounded-2xl border border-slate-100 bg-white/70 p-6">
+                  <div className="mb-5 flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100">
+                      <MapPin className="h-5 w-5 text-emerald-600" />
+                    </div>
+                    <div>
+                      <h3 className="text-base font-semibold text-slate-900">Adresse de livraison</h3>
+                      <p className="text-sm text-slate-500">Nous préparerons votre colis avec soin.</p>
+                    </div>
+                  </div>
+                  <div className="space-y-1 text-sm text-slate-600">
+                    <p className="font-medium text-slate-900">{order.address.fullName}</p>
+                    {order.address.company && <p>{order.address.company}</p>}
+                    <p>{order.address.address1}</p>
+                    {order.address.address2 && <p>{order.address.address2}</p>}
+                    <p>
+                      {order.address.postalCode} {order.address.city}
+                    </p>
+                    <p>{order.address.country}</p>
+                    {order.address.phone && (
+                      <p className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-slate-700">
+                        <Phone className="h-4 w-4 text-emerald-500" />
+                        {order.address.phone}
+                      </p>
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
 
-            {/* Total */}
-            <div className="border-t border-gray-200 pt-6">
-              <div className="flex justify-between text-lg font-medium text-gray-900 mb-4">
-                <span>Total</span>
-                <span>{order.total.toFixed(2)} €</span>
+              <div className="rounded-2xl border border-slate-100 bg-white/70 p-6">
+                <h3 className="text-base font-semibold text-slate-900">Total de la commande</h3>
+                <div className="mt-4 space-y-3 text-sm text-slate-600">
+                  <div className="flex justify-between">
+                    <span>Sous-total</span>
+                    <span className="font-medium text-slate-900">{order.subtotal.toFixed(2)} €</span>
+                  </div>
+                  {order.shipping?.price ? (
+                    <div className="flex justify-between">
+                      <span>Livraison</span>
+                      <span className="font-medium text-slate-900">{order.shipping.price.toFixed(2)} €</span>
+                    </div>
+                  ) : (
+                    <div className="flex justify-between">
+                      <span>Livraison</span>
+                      <span className="font-medium text-emerald-600">Offerte</span>
+                    </div>
+                  )}
+                </div>
+                <div className="mt-5 flex items-center justify-between border-t border-dashed border-slate-200 pt-5">
+                  <span className="text-lg font-semibold text-slate-900">Total TTC</span>
+                  <span className="text-2xl font-bold text-emerald-600">{order.total.toFixed(2)} €</span>
+                </div>
+                <p className="mt-2 text-xs uppercase tracking-wide text-slate-400">TVA incluse</p>
               </div>
-              <p className="text-sm text-gray-500">TVA incluse</p>
             </div>
           </div>
 
-          {/* Pied de page */}
-          <div className="bg-gray-50 px-6 py-4 text-center border-t border-gray-200">
-            <p className="text-gray-600 mb-4">
-              Vous avez des questions concernant votre commande ?<br />
-              Contactez-nous à <a href="mailto:contact@elecconnect.com" className="text-blue-600 hover:underline">contact@elecconnect.com</a>
-            </p>
-            <Link
-              href="/"
-              className="inline-flex items-center px-6 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
-            >
-              Retour à l'accueil
-            </Link>
-          </div>
+          <aside className="space-y-6">
+            <div className="rounded-3xl border border-slate-200/80 bg-white/80 p-8 shadow-lg shadow-emerald-600/5 backdrop-blur">
+              <h3 className="text-xl font-semibold text-slate-900">Prochaines étapes</h3>
+              <p className="mt-2 text-sm text-slate-600">
+                Nous préparons votre commande. Vous recevrez un email dès qu’elle sera expédiée.
+              </p>
+              <ul className="mt-6 space-y-4 text-sm text-slate-600">
+                <li className="flex gap-3">
+                  <span className="mt-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-emerald-50 text-emerald-600">
+                    <CheckCircle2 className="h-4 w-4" />
+                  </span>
+                  <div>
+                    <p className="font-medium text-slate-900">Confirmation reçue</p>
+                    <p>Votre commande est bien enregistrée dans notre système.</p>
+                  </div>
+                </li>
+                <li className="flex gap-3">
+                  <span className="mt-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-emerald-50 text-emerald-600">
+                    <Truck className="h-4 w-4" />
+                  </span>
+                  <div>
+                    <p className="font-medium text-slate-900">Préparation & expédition</p>
+                    <p>Nous vous notifierons dès que le colis est remis au transporteur.</p>
+                  </div>
+                </li>
+                <li className="flex gap-3">
+                  <span className="mt-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-emerald-50 text-emerald-600">
+                    <Home className="h-4 w-4" />
+                  </span>
+                  <div>
+                    <p className="font-medium text-slate-900">Livraison</p>
+                    <p>La réception est prévue sous 3 à 5 jours ouvrés après expédition.</p>
+                  </div>
+                </li>
+              </ul>
+            </div>
+
+            <div className="rounded-3xl border border-emerald-100 bg-emerald-50/60 p-8 text-center shadow-inner">
+                <h4 className="text-lg font-semibold text-emerald-800">Besoin d’aide ?</h4>
+              <p className="mt-2 text-sm text-emerald-700">
+                Notre équipe est disponible pour répondre à toutes vos questions sur votre commande.
+              </p>
+              <div className="mt-6 flex flex-col gap-3">
+                <a
+                  href="mailto:contact@elecconnect.com"
+                  className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-medium text-emerald-700 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+                >
+                  <Mail className="h-4 w-4" />
+                  contact@elecconnect.com
+                </a>
+                <Link
+                  href="/"
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-emerald-200 px-5 py-3 text-sm font-semibold text-emerald-800 transition hover:-translate-y-0.5 hover:bg-white"
+                >
+                  <ArrowRight className="h-4 w-4" />
+                  Retourner à l’accueil
+                </Link>
+              </div>
+            </div>
+          </aside>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- redesign the success confirmation page with a gradient hero header and two-column layout inspired by the main site aesthetics
- enrich order details with stylized cards for summary, shipping, address, and totals using Emerald/Sand palette
- add contextual support and next steps panels with matching iconography for a cohesive post-purchase experience

## Testing
- npx eslint app/success/page.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d3ebbfb7cc8333a50decf6495e7348