### PR TITLE
refactor: refresh success page styling

### DIFF
--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -135,41 +135,45 @@ function SuccessPage() {
   });
 
   return (
-    <section className="relative min-h-screen bg-[radial-gradient(circle_at_top,_#dcfce7,_#f8fafc)] py-16 px-4 sm:px-8">
-      <div className="absolute inset-x-0 top-10 -z-10 h-[420px] bg-gradient-to-b from-emerald-200/60 via-white to-transparent blur-3xl" />
-      <div className="max-w-5xl mx-auto">
-        <div className="relative overflow-hidden rounded-3xl border border-emerald-100/70 bg-white/80 shadow-2xl shadow-emerald-200/40 backdrop-blur">
-          <div className="absolute -top-24 left-1/2 -translate-x-1/2">
-            <div className="rounded-full border border-white/60 bg-gradient-to-br from-emerald-500 via-emerald-400 to-emerald-600 p-[1px] shadow-2xl">
-              <div className="flex size-28 items-center justify-center rounded-full bg-white text-emerald-600 shadow-lg shadow-emerald-200/60">
+    <section className="relative min-h-screen overflow-hidden bg-gradient-to-br from-amber-50 via-rose-50 to-white py-16 px-4 sm:px-8">
+      <div className="pointer-events-none absolute inset-0 -z-10 opacity-80">
+        <div className="absolute -right-20 top-24 h-64 w-64 rounded-full bg-amber-100 blur-3xl" />
+        <div className="absolute -left-10 top-40 h-72 w-72 rounded-full bg-orange-100 blur-[120px]" />
+        <div className="absolute bottom-0 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-pink-100/70 blur-[160px]" />
+      </div>
+      <div className="mx-auto max-w-5xl">
+        <div className="relative overflow-hidden rounded-[2.5rem] border border-orange-100/80 bg-white/70 shadow-[0_40px_120px_-60px_rgba(15,23,42,0.45)] backdrop-blur-xl">
+          <div className="absolute -top-24 left-1/2 hidden -translate-x-1/2 sm:block">
+            <div className="rounded-full border border-white/70 bg-gradient-to-br from-orange-400 via-amber-300 to-rose-300 p-[1px] shadow-[0_25px_60px_-25px_rgba(217,119,6,0.55)]">
+              <div className="flex size-28 items-center justify-center rounded-full bg-white text-orange-500 shadow-xl shadow-orange-200/70">
                 <CheckCircle2 className="h-14 w-14" strokeWidth={1.8} />
               </div>
             </div>
           </div>
 
-          <div className="overflow-hidden rounded-t-3xl bg-gradient-to-br from-emerald-600 via-emerald-500 to-emerald-400 px-8 pb-16 pt-32 text-center text-white">
-            <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em]">
+          <div className="overflow-hidden rounded-t-[2.5rem] bg-gradient-to-br from-orange-200 via-amber-100 to-rose-100 px-8 pb-16 pt-20 text-center text-slate-800 sm:pt-32">
+            <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-5 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-orange-500">
               Commande validée
             </span>
-            <h1 className="mt-6 text-3xl font-semibold leading-tight sm:text-4xl">
+            <h1 className="mt-6 text-3xl font-semibold leading-tight text-slate-900 sm:text-4xl">
               Merci pour votre confiance !
             </h1>
-            <p className="mt-4 text-base text-emerald-50/90 sm:text-lg">
+            <p className="mt-4 text-base text-slate-600 sm:text-lg">
               Un email de confirmation a été envoyé à {user?.emailAddresses?.[0]?.emailAddress}. Vous recevrez une notification dès que votre commande sera expédiée.
             </p>
           </div>
 
           <div className="px-6 pb-12 pt-10 sm:px-10 sm:pb-14 sm:pt-12">
-            <div className="grid gap-6 lg:grid-cols-2">
+            <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
               <div className="space-y-6">
-                <div className="rounded-2xl border border-emerald-100/80 bg-white/80 p-6 shadow-sm shadow-emerald-100/40">
+                <div className="rounded-3xl border border-orange-100/80 bg-white/70 p-6 shadow-[0_20px_60px_-40px_rgba(217,119,6,0.5)]">
                   <div className="flex items-start gap-4">
-                    <div className="flex size-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-600">
+                    <div className="flex size-12 items-center justify-center rounded-2xl bg-orange-100 text-orange-500">
                       <PackageCheck className="h-6 w-6" />
                     </div>
                     <div>
-                      <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Commande #{order.orderNumber}</p>
-                      <p className="mt-1 flex items-center gap-2 text-sm text-slate-500">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-500">Commande #{order.orderNumber}</p>
+                      <p className="mt-2 flex items-center gap-2 text-sm text-slate-500">
                         <CalendarDays className="h-4 w-4" />
                         {orderDate}
                       </p>
@@ -177,27 +181,27 @@ function SuccessPage() {
                   </div>
                 </div>
 
-                <div className="rounded-2xl border border-emerald-100/80 bg-white/80 p-6 shadow-sm shadow-emerald-100/40">
+                <div className="rounded-3xl border border-orange-100/80 bg-white/70 p-6 shadow-[0_20px_60px_-40px_rgba(217,119,6,0.5)]">
                   <div className="flex items-start gap-4">
-                    <div className="flex size-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-600">
+                    <div className="flex size-12 items-center justify-center rounded-2xl bg-orange-100 text-orange-500">
                       <Wallet className="h-6 w-6" />
                     </div>
                     <div className="flex-1">
-                      <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Montant total</p>
-                      <p className="mt-2 text-2xl font-semibold text-slate-900">{order.total} €</p>
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-500">Montant total</p>
+                      <p className="mt-2 text-3xl font-semibold text-slate-900">{order.total} €</p>
                       <p className="mt-1 text-sm text-slate-500">TVA incluse et frais éventuels déjà calculés.</p>
                     </div>
                   </div>
                 </div>
 
                 {order.shipping && (
-                  <div className="rounded-2xl border border-emerald-100/80 bg-white/80 p-6 shadow-sm shadow-emerald-100/40">
+                  <div className="rounded-3xl border border-orange-100/80 bg-white/70 p-6 shadow-[0_20px_60px_-40px_rgba(217,119,6,0.5)]">
                     <div className="flex items-start gap-4">
-                      <div className="flex size-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-600">
+                      <div className="flex size-12 items-center justify-center rounded-2xl bg-orange-100 text-orange-500">
                         <Truck className="h-6 w-6" />
                       </div>
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Livraison</p>
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-500">Livraison</p>
                         <p className="mt-2 text-base font-semibold text-slate-900">
                           {order.shipping.carrier || "Livraison standard"}
                         </p>
@@ -211,15 +215,16 @@ function SuccessPage() {
               </div>
 
               {order.address && (
-                <div className="flex h-full flex-col justify-between gap-6 rounded-3xl border border-slate-100 bg-white/90 p-6 shadow-lg shadow-emerald-100/30">
-                  <div>
-                    <div className="flex items-start gap-4">
-                      <div className="flex size-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-600">
+                <div className="flex h-full flex-col justify-between gap-6 rounded-[2.25rem] border border-rose-100/80 bg-white/70 p-6 shadow-[0_25px_80px_-55px_rgba(190,18,60,0.35)]">
+                  <div className="relative overflow-hidden rounded-[1.75rem] bg-rose-50/60 p-6">
+                    <div className="pointer-events-none absolute right-0 top-0 h-32 w-32 translate-x-1/4 -translate-y-1/4 rounded-full bg-white/40 blur-2xl" />
+                    <div className="relative flex items-start gap-4">
+                      <div className="flex size-12 items-center justify-center rounded-2xl bg-white text-rose-500 shadow-sm">
                         <MapPin className="h-6 w-6" />
                       </div>
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Adresse de livraison</p>
-                        <div className="mt-3 space-y-1 text-sm text-slate-600">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-rose-500">Adresse de livraison</p>
+                        <div className="mt-4 space-y-2 text-sm text-slate-600">
                           <p className="font-semibold text-slate-900">{order.address.fullName}</p>
                           {order.address.company && <p className="text-slate-500">{order.address.company}</p>}
                           <p>{order.address.address1}</p>
@@ -229,7 +234,9 @@ function SuccessPage() {
                           </p>
                           <p>{order.address.country}</p>
                           {order.address.phone && (
-                            <p className="pt-2 text-xs uppercase tracking-wide text-slate-400">Tél : <span className="font-medium text-slate-600 normal-case">{order.address.phone}</span></p>
+                            <p className="pt-2 text-xs uppercase tracking-[0.2em] text-slate-400">
+                              Tél : <span className="font-medium text-slate-600 normal-case">{order.address.phone}</span>
+                            </p>
                           )}
                         </div>
                       </div>
@@ -239,20 +246,20 @@ function SuccessPage() {
               )}
             </div>
 
-            <div className="mt-12 flex flex-col items-center gap-6 rounded-2xl border border-emerald-100/70 bg-emerald-50/60 px-6 py-8 text-center shadow-inner">
-            <p className="max-w-2xl text-sm text-slate-600 sm:text-base">
+            <div className="mt-12 flex flex-col items-center gap-6 rounded-[2rem] border border-orange-100/80 bg-orange-50/70 px-6 py-8 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.6)]">
+              <p className="max-w-2xl text-sm text-slate-600 sm:text-base">
                 Une question sur votre commande ? Notre équipe est à votre écoute pour vous accompagner dans l&apos;installation et le suivi de votre solution de recharge.
-            </p>
+              </p>
               <div className="flex flex-col items-center gap-4 sm:flex-row">
                 <a
                   href="mailto:contact@elecconnect.com"
-                  className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white px-5 py-2.5 text-sm font-semibold text-emerald-700 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-300 hover:text-emerald-800"
+                  className="inline-flex items-center gap-2 rounded-full border border-orange-200 bg-white px-5 py-2.5 text-sm font-semibold text-orange-500 shadow-sm transition hover:-translate-y-0.5 hover:border-orange-300 hover:text-orange-600"
                 >
                   <Mail className="h-4 w-4" /> contact@elecconnect.com
                 </a>
                 <Link
                   href="/"
-                  className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-slate-900/20 transition hover:-translate-y-0.5 hover:bg-slate-800"
+                  className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-slate-900/15 transition hover:-translate-y-0.5 hover:bg-slate-800"
                 >
                   Retour à l&apos;accueil
                   <ArrowRight className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- rework the success page visuals with a soft nude gradient background and blurred accent orbs
- redesign the order summary, payment and shipping cards with rounded glassmorphism styling that matches the site's neutral palette
- refresh the contact block and icon colors for a cohesive modern finish

## Testing
- npm run lint *(fails: existing lint errors outside the scope of this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d40f1d61ac833382893fd8414dd220