### PR TITLE
Fix cart total computation using Strapi product prices

### DIFF
--- a/app/api/cart-total/route.ts
+++ b/app/api/cart-total/route.ts
@@ -1,6 +1,62 @@
 import { NextResponse } from "next/server";
 import productApi from "@/app/strapi/productApis";
 
+type CartTotalItem = {
+  id: string | number;
+  quantity: number;
+};
+
+type StrapiProduct = {
+  price?: unknown;
+  attributes?: {
+    price?: unknown;
+  };
+};
+
+const parsePrice = (product: StrapiProduct | null | undefined): number => {
+  const candidates = [product?.price, product?.attributes?.price];
+
+  for (const value of candidates) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+
+    if (typeof value === "string") {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+
+  return 0;
+};
+
+const normalizeProduct = (response: unknown): StrapiProduct | null => {
+  if (!response || typeof response !== "object") {
+    return null;
+  }
+
+  const data = (response as { data?: unknown }).data;
+  if (Array.isArray(data)) {
+    return (data[0] as StrapiProduct | undefined) ?? null;
+  }
+
+  if (data && typeof data === "object") {
+    return data as StrapiProduct;
+  }
+
+  return null;
+};
+
+const toSafeQuantity = (value: unknown): number => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 0;
+  }
+  return parsed;
+};
+
 export async function POST(request: Request) {
   try {
     const { items } = await request.json();
@@ -9,13 +65,20 @@ export async function POST(request: Request) {
     }
 
     const totals = await Promise.all(
-      items.map(async (item: { id: string | number; quantity: number }) => {
-        const id = String(item.id);
-        const quantity = Number(item.quantity) || 0;
-        const res = await productApi.getProductById(id);
-        const data = res?.data?.data?.[0] ?? res?.data?.data;
-        const price = data?.price ?? 0;
-        return price * quantity;
+      items.map(async (item: CartTotalItem) => {
+        if (!item || (typeof item.id !== "string" && typeof item.id !== "number")) {
+          return 0;
+        }
+
+        const quantity = toSafeQuantity(item.quantity);
+        if (quantity === 0) {
+          return 0;
+        }
+
+        const res = await productApi.getProductById(String(item.id));
+        const product = normalizeProduct(res?.data ?? null);
+        const unitPrice = parsePrice(product);
+        return unitPrice * quantity;
       })
     );
 


### PR DESCRIPTION
## Summary
- normalize the Strapi product payload returned by getProductById before calculating totals
- handle prices coming from either the root or attributes object and ignore invalid cart quantities

## Testing
- npm run lint *(fails: pre-existing lint issues across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d449e32fd8833385f5f51db0564466