### PR TITLE
feat(cart): share totals across checkout

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -17,7 +17,7 @@ const toCartKey = (item: CartItem) =>
 
 function CartPage() {
   const router = useRouter();
-  const { cart, addToCart, removeFromCart } = useContext(
+  const { cart, addToCart, removeFromCart, syncCartTotals } = useContext(
     CartContext
   ) as CartContextType;
 
@@ -118,7 +118,10 @@ function CartPage() {
 
         const data = await res.json();
         const parsedTotal = Number(data.total);
-        setSubtotal(Number.isFinite(parsedTotal) ? parsedTotal : 0);
+        const sanitizedSubtotal = Number.isFinite(parsedTotal)
+          ? parsedTotal
+          : 0;
+        setSubtotal(sanitizedSubtotal);
       } catch (err) {
         console.error("Failed to calculate total", err);
         setSubtotal(0);
@@ -131,6 +134,10 @@ function CartPage() {
   useEffect(() => {
     setTotal(calculateTotalWithPromotion(subtotal, appliedPromotion));
   }, [appliedPromotion, subtotal]);
+
+  useEffect(() => {
+    syncCartTotals({ subtotal, total });
+  }, [subtotal, total, syncCartTotals]);
 
   const handleApplyPromotion = async () => {
     const trimmedCode = coupon.trim();


### PR DESCRIPTION
## Summary
- track cart subtotal and discounted total in the cart context for reuse
- synchronize the stored totals from the cart page when promotions are applied
- update the shipping step to reuse shared totals and show the applied reduction

## Testing
- `npm run lint` *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4503d9ca08333a34b2967416ceba0