### PR TITLE
Persist shipping method selection in cart context

### DIFF
--- a/app/checkout/shipping/page.tsx
+++ b/app/checkout/shipping/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import React, { useMemo, useState, useContext, useEffect } from "react";
+import { useMemo, useContext, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { CartContext, CartContextType, CartItem, MAX_PER_PRODUCT } from "../../contexts/CartContext";
+import {
+  CartContext,
+  CartContextType,
+  CartItem,
+  MAX_PER_PRODUCT,
+} from "../../contexts/CartContext";
 
 function groupCart(cart: (CartItem | null | undefined)[]) {
   const map = new Map<string, { item: CartItem; quantity: number }>();
@@ -29,9 +34,14 @@ async function createCheckoutSession(items: { title?: string; price: number; qua
 
 export default function ShippingStepPage() {
   const router = useRouter();
-  const { cart, cartSubtotal, cartTotal, cartTotalsUpdatedAt } = useContext(
-    CartContext
-  ) as CartContextType;
+  const {
+    cart,
+    cartSubtotal,
+    cartTotal,
+    cartTotalsUpdatedAt,
+    shippingMethod,
+    setShippingMethod,
+  } = useContext(CartContext) as CartContextType;
   const groups = useMemo(() => groupCart(cart), [cart]);
 
   useEffect(() => {
@@ -39,8 +49,6 @@ export default function ShippingStepPage() {
       router.replace("/cart");
     }
   }, [groups, router]);
-
-  const [shippingMethod, setShippingMethod] = useState<"standard" | "express">("standard");
 
   const handleProceedToPayment = async () => {
     // Build line items from cart

--- a/app/contexts/CartContext.tsx
+++ b/app/contexts/CartContext.tsx
@@ -19,11 +19,15 @@ export type CartItem = {
   };
 };
 
+export type ShippingMethod = "standard" | "express";
+
 export type CartContextType = {
   cart: CartItem[];
   cartSubtotal: number;
   cartTotal: number;
   cartTotalsUpdatedAt: number;
+  shippingMethod: ShippingMethod;
+  setShippingMethod: (method: ShippingMethod) => void;
   addToCart: (item: CartItem) => void;
   removeFromCart: (id: string | number) => void;
   updateCartItemQuantity: (id: string | number, quantity: number) => void;
@@ -106,6 +110,14 @@ export function CartProvider({ children }: { children: ReactNode }) {
   const [cartSubtotal, setCartSubtotal] = useState(0);
   const [cartTotal, setCartTotal] = useState(0);
   const [cartTotalsUpdatedAt, setCartTotalsUpdatedAt] = useState(0);
+  const [shippingMethod, setShippingMethodState] = useState<ShippingMethod>(
+    "standard"
+  );
+
+  const updateShippingMethod = useCallback((method: ShippingMethod) => {
+    setShippingMethodState(method);
+    localStorage.setItem("shippingMethod", method);
+  }, []);
 
   const clearCartTotals = useCallback(() => {
     setCartSubtotal(0);
@@ -127,8 +139,12 @@ export function CartProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const storedCart = localStorage.getItem("cart");
+    const storedShippingMethod = localStorage.getItem("shippingMethod");
 
     if (!storedCart) {
+      if (storedShippingMethod === "standard" || storedShippingMethod === "express") {
+        setShippingMethodState(storedShippingMethod);
+      }
       return;
     }
 
@@ -141,6 +157,10 @@ export function CartProvider({ children }: { children: ReactNode }) {
       }
     } catch {
       // ignore malformed data
+    }
+
+    if (storedShippingMethod === "standard" || storedShippingMethod === "express") {
+      setShippingMethodState(storedShippingMethod);
     }
   }, []);
 
@@ -170,6 +190,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
     setCart([]);
     localStorage.removeItem("cart");
     clearCartTotals();
+    setShippingMethodState("standard");
+    localStorage.removeItem("shippingMethod");
   }, [clearCartTotals]);
 
   const updateCartItemQuantity = useCallback((id: string | number, quantity: number) => {
@@ -189,6 +211,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
       cartSubtotal,
       cartTotal,
       cartTotalsUpdatedAt,
+      shippingMethod,
+      setShippingMethod: updateShippingMethod,
       addToCart,
       removeFromCart,
       updateCartItemQuantity,

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -45,7 +45,9 @@ interface Order {
 }
 
 function SuccessPage() {
-  const { cart, clearCart } = useContext(CartContext) as CartContextType;
+  const { cart, clearCart, shippingMethod } = useContext(
+    CartContext
+  ) as CartContextType;
   const { user } = useUser();
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(true);
@@ -68,7 +70,8 @@ function SuccessPage() {
           body: JSON.stringify({
             cart: cart.map(({ id, documentId }) => ({ id, documentId })),
             stripeSessionId,
-            userEmail: user?.emailAddresses?.[0]?.emailAddress
+            userEmail: user?.emailAddresses?.[0]?.emailAddress,
+            shippingMethod,
           }),
         });
 
@@ -103,7 +106,7 @@ function SuccessPage() {
     if (user && cart.length > 0) {
       createOrder();
     }
-  }, [cart, clearCart, router, user]);
+  }, [cart, clearCart, router, shippingMethod, user]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- store the selected shipping method in the cart context with localStorage persistence
- update the checkout shipping step to use the shared shipping method selection
- send the shipping method when creating orders and compute carrier/price on the API

## Testing
- npm run lint *(fails: pre-existing lint errors across the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d4679409288333af987d0692aec74a