### PR TITLE
Persist checkout addresses in cart context

### DIFF
--- a/app/api/order/route.ts
+++ b/app/api/order/route.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import { NextResponse } from "next/server";
-import { auth, currentUser } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 import orderApis from "@/app/strapi/orderApis";
 import productApis from "@/app/strapi/productApis";
 import { STRIPE_SECRET_KEY } from "@/app/lib/serverEnv";
@@ -10,9 +10,28 @@ type CartItemPayload = {
   documentId?: string;
 };
 
+type ShippingMethod = "standard" | "express";
+
+type CheckoutAddress = {
+  firstName?: string;
+  lastName?: string;
+  company?: string;
+  address1?: string;
+  address2?: string;
+  city?: string;
+  postalCode?: string;
+  country?: string;
+  phone?: string;
+  email?: string;
+};
+
 type RequestBody = {
   cart?: CartItemPayload[];
   stripeSessionId?: string;
+  shippingMethod?: ShippingMethod;
+  userEmail?: string;
+  shippingAddress?: CheckoutAddress;
+  billingAddress?: CheckoutAddress;
 };
 
 type OrderLineInput = {
@@ -21,9 +40,36 @@ type OrderLineInput = {
   unitPrice: number;
 };
 
-const SHIPPING_DETAILS = { carrier: "DHL", price: 9.99 } as const;
+const SHIPPING_OPTIONS: Record<ShippingMethod, { carrier: string; price: number }> = {
+  standard: { carrier: "Colissimo Standard", price: 0 },
+  express: { carrier: "Chronopost Express", price: 12.9 },
+};
 
 const toStringId = (value: string | number) => String(value);
+
+const sanitizeText = (value: unknown) =>
+  typeof value === "string" ? value.trim() : undefined;
+
+const formatAddress = (address?: CheckoutAddress) => {
+  if (!address) {
+    return undefined;
+  }
+
+  const firstName = sanitizeText(address.firstName) ?? "";
+  const lastName = sanitizeText(address.lastName) ?? "";
+  const fullName = `${firstName} ${lastName}`.trim();
+
+  return {
+    fullName: fullName || undefined,
+    company: sanitizeText(address.company),
+    address1: sanitizeText(address.address1),
+    address2: sanitizeText(address.address2),
+    postalCode: sanitizeText(address.postalCode),
+    city: sanitizeText(address.city),
+    country: sanitizeText(address.country),
+    phone: sanitizeText(address.phone),
+  };
+};
 
 async function buildOrderLines(
   items: Array<[string, { quantity: number }]>
@@ -84,7 +130,23 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    const { cart, stripeSessionId, userEmail } = await request.json();
+    const {
+      cart,
+      stripeSessionId,
+      userEmail,
+      shippingMethod,
+      shippingAddress: shippingAddressPayload,
+      billingAddress: billingAddressPayload,
+    }: RequestBody = await request.json();
+
+    const selectedShippingMethod:
+      | ShippingMethod
+      | undefined = shippingMethod;
+    const resolvedShippingMethod: ShippingMethod =
+      selectedShippingMethod === "express" || selectedShippingMethod === "standard"
+        ? selectedShippingMethod
+        : "standard";
+    const shippingDetails = SHIPPING_OPTIONS[resolvedShippingMethod];
 
         // Vérification CRITIQUE de la session Stripe
         if (!stripeSessionId) {
@@ -163,34 +225,18 @@ export async function POST(request: Request) {
       );
     }
 
-    const total = subtotal + SHIPPING_DETAILS.price;
+    const total = subtotal + shippingDetails.price;
 
     const orderResponse = await orderApis.createOrder({
       data: {
         orderNumber: randomUUID(),
         userId,
         userEmail,
-        shippingAddress: {
-          fullName: "Jean Dupont",
-          company: "Ma Société",
-          address1: "12 rue des Fleurs",
-          address2: "Appartement 34",
-          postalCode: 75001,
-          city: "Paris",
-          country: "France",
-          phone: 33123456789,
-        },
-        billingAddress: {
-          fullName: "Jean Dupont",
-          company: "Ma Société",
-          address1: "12 rue des Fleurs",
-          address2: "Appartement 34",
-          postalCode: 75001,
-          city: "Paris",
-          country: "France",
-          phone: 33123456789,
-        },
-        shipping: SHIPPING_DETAILS,
+        shippingAddress: formatAddress(shippingAddressPayload),
+        billingAddress: formatAddress(
+          billingAddressPayload ?? shippingAddressPayload
+        ),
+        shipping: shippingDetails,
         subtotal,
         total,
         orderStatus: "pending",

--- a/app/checkout/address/page.tsx
+++ b/app/checkout/address/page.tsx
@@ -1,79 +1,42 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useContext } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-
-type Address = {
-  firstName: string;
-  lastName: string;
-  company?: string;
-  address1: string;
-  address2?: string;
-  city: string;
-  postalCode: string;
-  country: string;
-  phone?: string;
-  email?: string;
-};
+import {
+  CartContext,
+  CartContextType,
+  CheckoutAddress,
+} from "@/app/contexts/CartContext";
 
 export default function AddressStepPage() {
   const router = useRouter();
-  const [shipping, setShipping] = useState<Address>({
-    firstName: "",
-    lastName: "",
-    company: "",
-    address1: "",
-    address2: "",
-    city: "",
-    postalCode: "",
-    country: "",
-    phone: "",
-    email: "",
-  });
-
-  const [useSameForBilling, setUseSameForBilling] = useState(true);
-  const [billing, setBilling] = useState<Address>({
-    firstName: "",
-    lastName: "",
-    company: "",
-    address1: "",
-    address2: "",
-    city: "",
-    postalCode: "",
-    country: "",
-    phone: "",
-    email: "",
-  });
-
-  // Load any saved data
-  useEffect(() => {
-    try {
-      const raw = localStorage.getItem("checkoutAddresses");
-      if (raw) {
-        const parsed = JSON.parse(raw);
-        if (parsed?.shipping) setShipping(parsed.shipping);
-        if (typeof parsed?.useSameForBilling === "boolean") setUseSameForBilling(parsed.useSameForBilling);
-        if (parsed?.billing) setBilling(parsed.billing);
-      }
-    } catch {}
-  }, []);
+  const {
+    shippingAddress,
+    billingAddress,
+    useSameAddressForBilling,
+    updateShippingAddress,
+    updateBillingAddress,
+    setUseSameAddressForBilling,
+  } = useContext(CartContext) as CartContextType;
 
   const saveAndContinue = () => {
-    const payload = { shipping, billing: useSameForBilling ? shipping : billing, useSameForBilling };
-    localStorage.setItem("checkoutAddresses", JSON.stringify(payload));
     router.push("/checkout/shipping");
   };
 
-  const onChangeFactory = (
-    setter: React.Dispatch<React.SetStateAction<Address>>
-  ) =>
-    (field: keyof Address) =>
+  const onChangeFactory =
+    (
+      updater: (updates: Partial<CheckoutAddress>) => void
+    ) =>
+    (field: keyof CheckoutAddress) =>
       (e: React.ChangeEvent<HTMLInputElement>) =>
-        setter((prev) => ({ ...prev, [field]: e.target.value }));
+        updater({ [field]: e.target.value });
 
-  const s = onChangeFactory(setShipping);
-  const b = onChangeFactory(setBilling);
+  const shipping = shippingAddress;
+  const billing = billingAddress;
+  const useSameForBilling = useSameAddressForBilling;
+  const s = onChangeFactory(updateShippingAddress);
+  const b = onChangeFactory(updateBillingAddress);
 
   return (
     <section className="bg-gray-50">
@@ -102,7 +65,7 @@ export default function AddressStepPage() {
           {/* Billing toggle */}
           <div className="bg-white rounded-lg border border-gray-100 shadow-sm p-5">
             <label className="flex items-center gap-2">
-              <input type="checkbox" className="checkbox checkbox-sm" checked={useSameForBilling} onChange={(e) => setUseSameForBilling(e.target.checked)} />
+              <input type="checkbox" className="checkbox checkbox-sm" checked={useSameForBilling} onChange={(e) => setUseSameAddressForBilling(e.target.checked)} />
               <span className="text-slate-800">Utiliser la même adresse pour la facturation</span>
             </label>
             {!useSameForBilling && (

--- a/app/checkout/shipping/page.tsx
+++ b/app/checkout/shipping/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import React, { useMemo, useState, useContext, useEffect } from "react";
+import { useMemo, useContext, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { CartContext, CartContextType, CartItem, MAX_PER_PRODUCT } from "../../contexts/CartContext";
+import {
+  CartContext,
+  CartContextType,
+  CartItem,
+  MAX_PER_PRODUCT,
+} from "../../contexts/CartContext";
 
 function groupCart(cart: (CartItem | null | undefined)[]) {
   const map = new Map<string, { item: CartItem; quantity: number }>();
@@ -29,9 +34,14 @@ async function createCheckoutSession(items: { title?: string; price: number; qua
 
 export default function ShippingStepPage() {
   const router = useRouter();
-  const { cart, cartSubtotal, cartTotal, cartTotalsUpdatedAt } = useContext(
-    CartContext
-  ) as CartContextType;
+  const {
+    cart,
+    cartSubtotal,
+    cartTotal,
+    cartTotalsUpdatedAt,
+    shippingMethod,
+    setShippingMethod,
+  } = useContext(CartContext) as CartContextType;
   const groups = useMemo(() => groupCart(cart), [cart]);
 
   useEffect(() => {
@@ -39,8 +49,6 @@ export default function ShippingStepPage() {
       router.replace("/cart");
     }
   }, [groups, router]);
-
-  const [shippingMethod, setShippingMethod] = useState<"standard" | "express">("standard");
 
   const handleProceedToPayment = async () => {
     // Build line items from cart

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -45,7 +45,16 @@ interface Order {
 }
 
 function SuccessPage() {
-  const { cart, clearCart } = useContext(CartContext) as CartContextType;
+  const {
+    cart,
+    clearCart,
+    shippingMethod,
+    shippingAddress,
+    billingAddress,
+    useSameAddressForBilling,
+  } = useContext(
+    CartContext
+  ) as CartContextType;
   const { user } = useUser();
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(true);
@@ -68,7 +77,12 @@ function SuccessPage() {
           body: JSON.stringify({
             cart: cart.map(({ id, documentId }) => ({ id, documentId })),
             stripeSessionId,
-            userEmail: user?.emailAddresses?.[0]?.emailAddress
+            userEmail: user?.emailAddresses?.[0]?.emailAddress,
+            shippingMethod,
+            shippingAddress,
+            billingAddress: useSameAddressForBilling
+              ? shippingAddress
+              : billingAddress,
           }),
         });
 
@@ -103,7 +117,16 @@ function SuccessPage() {
     if (user && cart.length > 0) {
       createOrder();
     }
-  }, [cart, clearCart, router, user]);
+  }, [
+    billingAddress,
+    cart,
+    clearCart,
+    router,
+    shippingAddress,
+    shippingMethod,
+    useSameAddressForBilling,
+    user,
+  ]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- track shipping and billing addresses in the cart context with persistence helpers and reset handling
- update the checkout address step to read and mutate the shared addresses instead of managing local state
- send the selected addresses when placing the order and store them on the backend order payload

## Testing
- npm run lint *(fails: numerous pre-existing lint errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d4679409288333af987d0692aec74a