### PR TITLE
Add Resend email test page and API route

### DIFF
--- a/app/api/test-email/route.ts
+++ b/app/api/test-email/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+
+const RESEND_API_KEY =
+  process.env.RESEND_API_KEY ?? "re_hNMWqpKj_KUj6JCJ5rkpczCrUkC14dDuL";
+
+interface RequestPayload {
+  to?: string;
+  subject?: string;
+  message?: string;
+}
+
+export async function POST(request: Request) {
+  const payload: RequestPayload = await request.json();
+  const to = payload.to?.trim();
+  const subject = payload.subject?.trim();
+  const message = payload.message?.trim();
+
+  if (!to || !subject || !message) {
+    return NextResponse.json(
+      {
+        error: "Merci de renseigner le destinataire, l’objet et le message.",
+      },
+      { status: 400 },
+    );
+  }
+
+  if (!RESEND_API_KEY) {
+    return NextResponse.json(
+      {
+          error:
+            "La clé API Resend est manquante. Merci de définir la variable RESEND_API_KEY.",
+      },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const response = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+      },
+      body: JSON.stringify({
+        from: "no-reply@updates.chajaratmaryam.fr",
+        to: [to],
+        subject,
+        html: `<!doctype html><html lang="fr"><body><div>${message.replace(/\n/g, "<br/>")}</div></body></html>`,
+        text: message,
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        {
+            error:
+              data?.message ?? "Resend a renvoyé une erreur lors de l’envoi.",
+          details: typeof data === "object" ? JSON.stringify(data) : String(data),
+        },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json({
+      id: data?.id,
+      data,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+          error: "Une erreur inattendue est survenue lors de l’appel à Resend.",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/test-email/page.tsx
+++ b/app/test-email/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+
+interface ApiResponse {
+  success: boolean;
+  message: string;
+  details?: string;
+}
+
+const DEFAULT_FORM = {
+  to: "",
+  subject: "",
+  message: "",
+};
+
+export default function TestEmailPage() {
+  const [formState, setFormState] = useState(DEFAULT_FORM);
+  const [status, setStatus] = useState<ApiResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsLoading(true);
+    setStatus(null);
+
+    try {
+      const response = await fetch("/api/test-email", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formState),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        setStatus({
+          success: false,
+          message: data?.error ?? "Une erreur est survenue lors de l’envoi du message.",
+          details: data?.details,
+        });
+      } else {
+        setStatus({
+          success: true,
+          message: "E-mail envoyé avec succès.",
+          details: data?.id ? `Identifiant: ${data.id}` : undefined,
+        });
+        setFormState(DEFAULT_FORM);
+      }
+    } catch (error) {
+      setStatus({
+        success: false,
+        message: "Impossible de joindre le service d’envoi d’e-mails.",
+        details: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto flex min-h-[calc(100vh-10rem)] max-w-3xl flex-col gap-6 px-4 py-12">
+      <div className="space-y-2 text-center">
+        <h1 className="text-3xl font-semibold">Test d’envoi d’e-mail</h1>
+        <p className="text-muted-foreground text-sm">
+          Utilisez ce formulaire pour envoyer un message de test via Resend.
+        </p>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm"
+      >
+        <div className="mb-4">
+          <label className="mb-1 block text-sm font-medium" htmlFor="to">
+            Destinataire
+          </label>
+          <input
+            id="to"
+            type="email"
+            required
+            value={formState.to}
+            onChange={(event) =>
+              setFormState((prev) => ({ ...prev, to: event.target.value }))
+            }
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none"
+            placeholder="exemple@domaine.com"
+          />
+        </div>
+
+        <div className="mb-4">
+          <label className="mb-1 block text-sm font-medium" htmlFor="subject">
+            Objet
+          </label>
+          <input
+            id="subject"
+            type="text"
+            required
+            value={formState.subject}
+            onChange={(event) =>
+              setFormState((prev) => ({ ...prev, subject: event.target.value }))
+            }
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none"
+            placeholder="Objet du message"
+          />
+        </div>
+
+        <div className="mb-6">
+          <label className="mb-1 block text-sm font-medium" htmlFor="message">
+            Message
+          </label>
+          <textarea
+            id="message"
+            required
+            rows={6}
+            value={formState.message}
+            onChange={(event) =>
+              setFormState((prev) => ({ ...prev, message: event.target.value }))
+            }
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none"
+            placeholder="Contenu de votre message"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full rounded-md bg-black px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-800 disabled:cursor-not-allowed disabled:bg-gray-500"
+        >
+          {isLoading ? "Envoi en cours..." : "Envoyer le test"}
+        </button>
+      </form>
+
+      {status && (
+        <div
+          className={`rounded-lg border p-4 text-sm ${
+            status.success
+              ? "border-green-200 bg-green-50 text-green-800"
+              : "border-red-200 bg-red-50 text-red-800"
+          }`}
+        >
+          <p className="font-medium">{status.message}</p>
+          {status.details && <p className="mt-1 text-xs">{status.details}</p>}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated `/test-email` page with a Resend-powered form to send test messages
- expose a `/api/test-email` route that posts to Resend using the verified domain sender and provided API key

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d578e71d6483339b506f25b692874c