### PR TITLE
Fetch Google reviews dynamically

### DIFF
--- a/app/components/landing/Reviews.tsx
+++ b/app/components/landing/Reviews.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Pagination } from "swiper/modules";
 import "swiper/css";
@@ -36,6 +36,14 @@ type GoogleReviewResponse = {
 };
 
 const FALLBACK_SECRET = "";
+
+const sanitizeRelativeTime = (value?: string) =>
+  value?.replace(/\u00A0/g, " ") ?? "";
+
+const getInitial = (value: string) => {
+  const trimmed = value.trim();
+  return trimmed ? trimmed.charAt(0).toUpperCase() : "?";
+};
 
 export default function Testimonials() {
   const [reviews, setReviews] = useState<GoogleReview[]>([]);
@@ -98,8 +106,10 @@ export default function Testimonials() {
       ? reviews.reduce((sum, review) => sum + review.rating, 0) /
         reviews.length
       : null);
-  const roundedAverageRating =
-    computedAverageRating != null ? Math.round(computedAverageRating) : 0;
+  const roundedAverageRating = useMemo(
+    () => (computedAverageRating != null ? Math.round(computedAverageRating) : 0),
+    [computedAverageRating],
+  );
 
   return (
     <section
@@ -190,58 +200,69 @@ export default function Testimonials() {
                       Aucun avis disponible pour le moment.
                     </SwiperSlide>
                   )}
-                  {reviews.map((review) => (
-                    <SwiperSlide
-                    key={`${review.author_name}-${review.time}`}
-                    className="bg-white rounded-[22px] overflow-hidden"
-                    style={{
-                      boxShadow:
-                        "0 26px 44px -18px rgba(2,6,23,0.25), 0 12px 24px rgba(2,6,23,0.08)",
-                      border: "2px solid rgba(226,232,240,1)", // slate-200
-                    }}
-                  >
-                    <div className="w-[86%] mx-auto h-full flex flex-col py-8">
-                      {/* HAUT : étoiles + note */}
-                      <div className="flex items-center justify-center gap-1.5 mb-8">
-                        {renderStars(review.rating)}
-                        <span className="ml-3 text-base md:text-lg font-semibold text-slate-700">
-                          {review.rating}/5
-                        </span>
-                      </div>
+                  {reviews.map((review) => {
+                    const relativeTime = sanitizeRelativeTime(
+                      review.relative_time_description,
+                    );
 
-                      {/* MILIEU : commentaire centré verticalement */}
-                      <div className="flex-1 flex items-center justify-center text-center">
-                        <p className="max-w-[42ch] text-[13px] sm:text-sm md:text-[15px] font-semibold text-slate-800 leading-relaxed">
-                          {review.text}
-                        </p>
-                      </div>
+                    return (
+                      <SwiperSlide
+                        key={`${review.author_name}-${review.time}`}
+                        className="bg-white rounded-[22px] overflow-hidden"
+                        style={{
+                          boxShadow:
+                            "0 26px 44px -18px rgba(2,6,23,0.25), 0 12px 24px rgba(2,6,23,0.08)",
+                          border: "2px solid rgba(226,232,240,1)", // slate-200
+                        }}
+                      >
+                        <div className="w-[86%] mx-auto h-full flex flex-col py-8">
+                          {/* HAUT : étoiles + note */}
+                          <div className="flex items-center justify-between gap-4 mb-8">
+                            <div className="flex items-center gap-1.5">
+                              {renderStars(review.rating)}
+                            </div>
+                            <span className="text-base md:text-lg font-semibold text-slate-700">
+                              {review.rating}/5
+                            </span>
+                          </div>
 
-                      {/* BAS : auteur */}
-                      <div className="flex items-center gap-4 mt-8">
-                        {review.profile_photo_url ? (
-                          <Image
-                            src={review.profile_photo_url}
-                            alt={review.author_name}
-                            width={56}
-                            height={56}
-                            className="rounded-full object-cover"
-                          />
-                        ) : (
-                          <div className="w-14 h-14 rounded-full bg-slate-200" />
-                        )}
+                          {/* MILIEU : commentaire centré verticalement */}
+                          <div className="flex-1 flex items-center justify-center text-center">
+                            <p className="max-w-[42ch] text-[13px] sm:text-sm md:text-[15px] font-semibold text-slate-800 leading-relaxed whitespace-pre-line">
+                              {review.text}
+                            </p>
+                          </div>
 
-                        <div>
-                          <p className="text-[15px] sm:text-lg font-semibold text-slate-900">
-                            {review.author_name}
-                          </p>
-                          <p className="text-slate-500 text-xs sm:text-sm">
-                            Avis Google{review.relative_time_description ? ` • ${review.relative_time_description}` : ""}
-                          </p>
+                          {/* BAS : auteur */}
+                          <div className="flex items-center gap-4 mt-8">
+                            {review.profile_photo_url ? (
+                              <Image
+                                src={review.profile_photo_url}
+                                alt={review.author_name}
+                                width={56}
+                                height={56}
+                                className="rounded-full object-cover"
+                              />
+                            ) : (
+                              <div className="w-14 h-14 rounded-full bg-slate-200 flex items-center justify-center text-lg font-semibold text-slate-600">
+                                {getInitial(review.author_name)}
+                              </div>
+                            )}
+
+                            <div>
+                              <p className="text-[15px] sm:text-lg font-semibold text-slate-900">
+                                {review.author_name}
+                              </p>
+                              <p className="text-slate-500 text-xs sm:text-sm">
+                                Avis Google
+                                {relativeTime ? ` • ${relativeTime}` : ""}
+                              </p>
+                            </div>
+                          </div>
                         </div>
-                      </div>
-                    </div>
-                  </SwiperSlide>
-                 ))}
+                      </SwiperSlide>
+                    );
+                  })}
                 </Swiper>
               </div>
             </div>

--- a/app/components/landing/Reviews.tsx
+++ b/app/components/landing/Reviews.tsx
@@ -38,6 +38,7 @@ type GoogleReviewResponse = {
 const FALLBACK_SECRET = "";
 
 const MOBILE_COMMENT_CHAR_LIMIT = 120;
+const DESKTOP_COMMENT_CHAR_LIMIT = 220;
 
 const sanitizeRelativeTime = (value?: string) =>
   value?.replace(/\u00A0/g, " ") ?? "";
@@ -250,9 +251,12 @@ export default function Testimonials() {
                           {/* MILIEU : commentaire centré verticalement */}
                           <div className="flex-1 flex items-center justify-center text-center">
                             <p className="max-w-[42ch] text-[13px] sm:text-sm md:text-[15px] font-semibold text-slate-800 leading-relaxed whitespace-pre-line">
-                              {isMobileViewport
-                                ? truncateText(review.text, MOBILE_COMMENT_CHAR_LIMIT)
-                                : review.text}
+                              {truncateText(
+                                review.text,
+                                isMobileViewport
+                                  ? MOBILE_COMMENT_CHAR_LIMIT
+                                  : DESKTOP_COMMENT_CHAR_LIMIT,
+                              )}
                             </p>
                           </div>
 

--- a/app/components/landing/Reviews.tsx
+++ b/app/components/landing/Reviews.tsx
@@ -37,7 +37,7 @@ type GoogleReviewResponse = {
 
 const FALLBACK_SECRET = "";
 
-const MOBILE_COMMENT_CHAR_LIMIT = 200;
+const MOBILE_COMMENT_CHAR_LIMIT = 120;
 
 const sanitizeRelativeTime = (value?: string) =>
   value?.replace(/\u00A0/g, " ") ?? "";

--- a/app/components/landing/Reviews.tsx
+++ b/app/components/landing/Reviews.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Pagination } from "swiper/modules";
 import "swiper/css";
@@ -12,61 +12,95 @@ import { EffectCards } from "swiper/modules";
 
 import Image from "next/image";
 import { Star as LucideStar } from "lucide-react";
+import { INTERNAL_SERVER_SECRET } from "@/app/lib/constants";
 
-type Review = {
-  id: number;
-  name: string;
-  role: string;
-  location: string;
+type GoogleReview = {
+  author_name: string;
+  author_url?: string;
+  profile_photo_url?: string;
   rating: number;
-  review: string;
-  image?: string; // optionnel: image avatar
+  relative_time_description?: string;
+  text: string;
+  time?: number;
 };
 
-const reviews: Review[] = [
-  {
-    id: 1,
-    name: "Marie Dubois",
-    role: "Particulier",
-    location: "Paris 15e",
-    rating: 5,
-    review:
-      "Installation parfaite de ma borne à domicile. L'équipe est très professionnelle et le service après-vente excellent.",
-    image: "/woman.jpg",
-  },
-  {
-    id: 2,
-    name: "Jean Martin",
-    role: "Copropriété",
-    location: "Boulogne-Billancourt",
-    rating: 5,
-    review:
-      "Très satisfait de l'installation en copropriété. Processus simple et équipe compétente.",
-    image: "/man.jpg",
-  },
-  {
-    id: 3,
-    name: "Sophie Laurent",
-    role: "Entreprise",
-    location: "La Défense",
-    rating: 5,
-    review:
-      "Service professionnel pour notre parking d'entreprise. Installation rapide et propre.",
-    image: "/woman.jpg",
-  },
-  {
-    id: 4,
-    name: "Pierre Durand",
-    role: "Particulier",
-    location: "Versailles",
-    rating: 5,
-    review:
-      "Excellent accompagnement du devis à l'installation. Je recommande vivement ELEC'CONNECT.",
-    image: "/man.jpg",
-  },
-];
+type GoogleReviewResponse = {
+  result?: {
+    rating?: number;
+    user_ratings_total?: number;
+    reviews?: GoogleReview[];
+  };
+  reviews?: GoogleReview[];
+  rating?: number;
+  user_ratings_total?: number;
+};
+
+const FALLBACK_SECRET = "";
 
 export default function Testimonials() {
+  const [reviews, setReviews] = useState<GoogleReview[]>([]);
+  const [averageRating, setAverageRating] = useState<number | null>(null);
+  const [totalRatings, setTotalRatings] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchReviews = async () => {
+      try {
+        const response = await fetch("/api/google-reviews", {
+          headers: {
+            "x-internal-secret": INTERNAL_SERVER_SECRET ?? FALLBACK_SECRET,
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error(`Erreur ${response.status}`);
+        }
+
+        const data: GoogleReviewResponse = await response.json();
+        const fetchedReviews =
+          data.result?.reviews ?? data.reviews ?? [];
+
+        setReviews(fetchedReviews);
+        setAverageRating(data.result?.rating ?? data.rating ?? null);
+        setTotalRatings(
+          data.result?.user_ratings_total ?? data.user_ratings_total ?? null,
+        );
+      } catch (err) {
+        console.error("Erreur lors de la récupération des avis Google:", err);
+        setError("Impossible de récupérer les avis pour le moment.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchReviews();
+  }, []);
+
+  const renderStars = (rating: number) => {
+    const filledStars = Math.round(rating);
+    return Array.from({ length: 5 }).map((_, i) => (
+      <svg
+        key={i}
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className={`w-7 h-7 md:w-8 md:h-8 ${i < filledStars ? "text-yellow-500" : "text-slate-300"}`}
+        aria-hidden="true"
+      >
+        <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.176 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81H7.03a1 1 0 00.95-.69l1.07-3.292z" />
+      </svg>
+    ));
+  };
+  const computedAverageRating =
+    averageRating ??
+    (reviews.length > 0
+      ? reviews.reduce((sum, review) => sum + review.rating, 0) /
+        reviews.length
+      : null);
+  const roundedAverageRating =
+    computedAverageRating != null ? Math.round(computedAverageRating) : 0;
+
   return (
     <section
       className="py-20 bg-[linear-gradient(135deg,_#ECFFF6_0%,_#E8FFF0_40%,_#E9FFF7_70%,_#F4FFF9_100%)]"
@@ -106,7 +140,11 @@ export default function Testimonials() {
 
                 <div className="mt-6">
                   <div className="flex items-baseline gap-4 mb-2">
-                    <span className="text-5xl font-bold text-slate-900">4.9</span>
+                    <span className="text-5xl font-bold text-slate-900">
+                      {computedAverageRating != null
+                        ? computedAverageRating.toFixed(1)
+                        : "—"}
+                    </span>
                     <span className="text-sm font-medium uppercase tracking-wide text-emerald-600">
                       Note moyenne
                     </span>
@@ -115,12 +153,15 @@ export default function Testimonials() {
                     {Array.from({ length: 5 }).map((_, i) => (
                       <LucideStar
                         key={i}
-                        className="w-6 h-6 text-yellow-400 fill-current"
+                        className={`w-6 h-6 ${i < roundedAverageRating ? "text-yellow-400" : "text-slate-300"}`}
+                        fill="currentColor"
                       />
                     ))}
                   </div>
                   <p className="text-sm text-slate-600">
-                    Basé sur plus de 200 avis clients vérifiés.
+                    {totalRatings ?? reviews.length
+                      ? `Basé sur ${totalRatings ?? reviews.length} avis clients vérifiés.`
+                      : "Avis Google authentiques."}
                   </p>
                 </div>
               </div>
@@ -134,9 +175,24 @@ export default function Testimonials() {
                   pagination={{ clickable: true }}
                   className="md:w-[450px] md:h-[350px] w-[90%] h-[320px] mx-auto"
                 >
-                  {reviews.map((d) => (
+                  {isLoading && (
+                    <SwiperSlide className="bg-white rounded-[22px] overflow-hidden flex items-center justify-center text-slate-600 text-sm">
+                      Chargement des avis...
+                    </SwiperSlide>
+                  )}
+                  {error && !isLoading && (
+                    <SwiperSlide className="bg-white rounded-[22px] overflow-hidden flex items-center justify-center text-center text-slate-600 text-sm px-6">
+                      {error}
+                    </SwiperSlide>
+                  )}
+                  {!isLoading && !error && reviews.length === 0 && (
+                    <SwiperSlide className="bg-white rounded-[22px] overflow-hidden flex items-center justify-center text-slate-600 text-sm">
+                      Aucun avis disponible pour le moment.
+                    </SwiperSlide>
+                  )}
+                  {reviews.map((review) => (
                     <SwiperSlide
-                    key={d.id}
+                    key={`${review.author_name}-${review.time}`}
                     className="bg-white rounded-[22px] overflow-hidden"
                     style={{
                       boxShadow:
@@ -147,36 +203,25 @@ export default function Testimonials() {
                     <div className="w-[86%] mx-auto h-full flex flex-col py-8">
                       {/* HAUT : étoiles + note */}
                       <div className="flex items-center justify-center gap-1.5 mb-8">
-                        {Array.from({ length: 5 }).map((_, i) => (
-                          <svg
-                            key={i}
-                            xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                            className={`w-7 h-7 md:w-8 md:h-8 ${i < d.rating ? "text-yellow-500" : "text-slate-300"}`}
-                            aria-hidden="true"
-                          >
-                            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.176 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81H7.03a1 1 0 00.95-.69l1.07-3.292z" />
-                          </svg>
-                        ))}
+                        {renderStars(review.rating)}
                         <span className="ml-3 text-base md:text-lg font-semibold text-slate-700">
-                          {d.rating}/5
+                          {review.rating}/5
                         </span>
                       </div>
-                  
+
                       {/* MILIEU : commentaire centré verticalement */}
                       <div className="flex-1 flex items-center justify-center text-center">
                         <p className="max-w-[42ch] text-[13px] sm:text-sm md:text-[15px] font-semibold text-slate-800 leading-relaxed">
-                          {d.review}
+                          {review.text}
                         </p>
                       </div>
-                  
+
                       {/* BAS : auteur */}
                       <div className="flex items-center gap-4 mt-8">
-                        {d.image ? (
+                        {review.profile_photo_url ? (
                           <Image
-                            src={d.image}
-                            alt={d.name}
+                            src={review.profile_photo_url}
+                            alt={review.author_name}
                             width={56}
                             height={56}
                             className="rounded-full object-cover"
@@ -184,13 +229,13 @@ export default function Testimonials() {
                         ) : (
                           <div className="w-14 h-14 rounded-full bg-slate-200" />
                         )}
-                  
+
                         <div>
                           <p className="text-[15px] sm:text-lg font-semibold text-slate-900">
-                            {d.name}
+                            {review.author_name}
                           </p>
                           <p className="text-slate-500 text-xs sm:text-sm">
-                            {d.role} • {d.location}
+                            Avis Google{review.relative_time_description ? ` • ${review.relative_time_description}` : ""}
                           </p>
                         </div>
                       </div>

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,11 @@ const nextConfig: NextConfig = {
         port: "1337",
         pathname: "/uploads/**",
       },
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        pathname: "/**",
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- replace the hard-coded landing page testimonials with reviews loaded from `/api/google-reviews`, sending the `INTERNAL_SERVER_SECRET` header
- add loading/error handling and dynamic rating summaries based on the API response
- allow Google profile photos to render by adding `lh3.googleusercontent.com` to the Next.js remote image patterns

## Testing
- npm run lint *(fails: pre-existing lint violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d701c72d08833398b089e38196110a