### PR TITLE
Adjust financing card images for better visibility

### DIFF
--- a/app/components/landing/SolarSolution.tsx
+++ b/app/components/landing/SolarSolution.tsx
@@ -78,12 +78,12 @@ export default function SolarSolution() {
           <div className="space-y-6">
             <div className="grid gap-6 sm:grid-cols-2">
               <div className="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 backdrop-blur">
-                <div className="relative h-48 w-full">
+                <div className="relative flex h-48 w-full items-center justify-center bg-slate-950/60 p-4">
                   <Image
                     src="/advenir.png"
                     alt="Programme de financement ADVENIR"
                     fill
-                    className="object-cover transition duration-500 group-hover:scale-105"
+                    className="object-contain transition duration-500 group-hover:scale-105"
                     sizes="(min-width: 1024px) 220px, (min-width: 640px) 50vw, 100vw"
                     priority
                   />
@@ -97,12 +97,12 @@ export default function SolarSolution() {
               </div>
 
               <div className="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 backdrop-blur">
-                <div className="relative h-48 w-full">
+                <div className="relative flex h-48 w-full items-center justify-center bg-slate-950/60 p-4">
                   <Image
                     src="/credit-impot.png"
                     alt="Crédit d’impôt pour borne de recharge"
                     fill
-                    className="object-cover transition duration-500 group-hover:scale-105"
+                    className="object-contain transition duration-500 group-hover:scale-105"
                     sizes="(min-width: 1024px) 220px, (min-width: 640px) 50vw, 100vw"
                   />
                 </div>


### PR DESCRIPTION
## Summary
- center financing card thumbnails on a darker backdrop so logos display fully
- switch images to use object-contain scaling to avoid cropping inside the cards

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc40308a2083338544d9f2fc6f1baa