### PR TITLE
Validate checkout prices against Strapi before creating Stripe sessions

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,28 +1,167 @@
 import Stripe from "stripe";
 import { NextResponse } from "next/server";
 import { STRIPE_SECRET_KEY } from "../../lib/serverEnv";
-import { LOCAL_URL, SERVER_URL } from "@/app/lib/constants";
+import { LOCAL_URL } from "@/app/lib/constants";
 import {
   checkoutSessionSchema,
   type CheckoutSessionPayload,
 } from "@/app/lib/validation/checkout";
+import productApis from "@/app/strapi/productApis";
 
 const stripe = new Stripe(STRIPE_SECRET_KEY as string);
 const DEFAULT_PRODUCT_NAME = "Produit ElecConnect";
+const MAX_PRICE_IN_CENTS = 50_000_000;
+const EXPRESS_SHIPPING_PRICE_IN_CENTS = 1290;
+const EXPRESS_SHIPPING_LABEL = "Livraison express";
 
-const buildLineItems = ({ items }: CheckoutSessionPayload) =>
-  items.map((item) => {
-    const unitAmount = Math.round(item.price * 100);
+class CheckoutValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CheckoutValidationError";
+  }
+}
 
-    return {
+type StrapiProduct = {
+  id?: string | number;
+  title?: unknown;
+  price?: unknown;
+  attributes?: {
+    title?: unknown;
+    price?: unknown;
+  };
+};
+
+const parsePrice = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const selectProductFromResponse = (response: unknown): StrapiProduct | null => {
+  if (!response || typeof response !== "object") {
+    return null;
+  }
+
+  if ("data" in response) {
+    const payload = (response as { data?: unknown }).data;
+    if (Array.isArray(payload)) {
+      return (payload[0] ?? null) as StrapiProduct | null;
+    }
+    if (payload && typeof payload === "object") {
+      return payload as StrapiProduct;
+    }
+  }
+
+  return response as StrapiProduct;
+};
+
+const resolveProductTitle = (product: StrapiProduct): string => {
+  const fromAttributes = product.attributes?.title;
+  if (typeof fromAttributes === "string" && fromAttributes.trim().length > 0) {
+    return fromAttributes.trim();
+  }
+
+  if (typeof product.title === "string" && product.title.trim().length > 0) {
+    return product.title.trim();
+  }
+
+  return DEFAULT_PRODUCT_NAME;
+};
+
+const toCheckoutLineItem = async (
+  item: CheckoutSessionPayload["items"][number]
+): Promise<Stripe.Checkout.SessionCreateParams.LineItem> => {
+  const productId = typeof item.id === "number" ? String(item.id) : item.id.trim();
+  if (!productId) {
+    throw new CheckoutValidationError(
+      "Un identifiant de produit fourni est invalide."
+    );
+  }
+
+  const response = await productApis.getProductById(productId);
+  const product = selectProductFromResponse(response?.data ?? null);
+
+  if (!product) {
+    throw new CheckoutValidationError(
+      "Un produit de la commande est introuvable."
+    );
+  }
+
+  const rawPrice =
+    product.attributes?.price !== undefined
+      ? product.attributes.price
+      : product.price;
+  const price = parsePrice(rawPrice);
+
+  if (price === null) {
+    throw new CheckoutValidationError(
+      "Le prix d'un produit de la commande est invalide."
+    );
+  }
+
+  const unitAmount = Math.round(price * 100);
+
+  if (!Number.isFinite(unitAmount) || unitAmount <= 0) {
+    throw new CheckoutValidationError(
+      "Le prix d'un produit de la commande est invalide."
+    );
+  }
+
+  if (unitAmount > MAX_PRICE_IN_CENTS) {
+    throw new CheckoutValidationError(
+      "Le prix d'un produit dépasse la limite autorisée."
+    );
+  }
+
+  return {
+    price_data: {
+      currency: "eur",
+      product_data: { name: resolveProductTitle(product) },
+      unit_amount: unitAmount,
+    },
+    quantity: item.quantity,
+  };
+};
+
+const buildLineItems = async (
+  payload: CheckoutSessionPayload
+): Promise<Stripe.Checkout.SessionCreateParams.LineItem[]> => {
+  const productLineItems = await Promise.all(
+    payload.items.map((item) => toCheckoutLineItem(item))
+  );
+
+  if (!productLineItems.length) {
+    throw new CheckoutValidationError(
+      "Aucun article valide n'a été trouvé dans la commande."
+    );
+  }
+
+  const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = [
+    ...productLineItems,
+  ];
+
+  if (payload.shippingMethod === "express") {
+    lineItems.push({
       price_data: {
         currency: "eur",
-        product_data: { name: item.title ?? DEFAULT_PRODUCT_NAME },
-        unit_amount: unitAmount,
+        product_data: { name: EXPRESS_SHIPPING_LABEL },
+        unit_amount: EXPRESS_SHIPPING_PRICE_IN_CENTS,
       },
-      quantity: item.quantity,
-    };
-  });
+      quantity: 1,
+    });
+  }
+
+  return lineItems;
+};
 
 export async function POST(request: Request) {
   try {
@@ -47,7 +186,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const line_items = buildLineItems(parsedBody.data);
+    const line_items = await buildLineItems(parsedBody.data);
 
     const session = await stripe.checkout.sessions.create({
       mode: "payment",
@@ -60,6 +199,13 @@ export async function POST(request: Request) {
     return NextResponse.json({ url: session.url });
   } catch (error) {
     console.error("Erreur lors de la création de la session de paiement", error);
+
+    if (error instanceof CheckoutValidationError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 400 }
+      );
+    }
 
     if (error instanceof Stripe.errors.StripeError) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary
- verify checkout line items against Strapi pricing before creating Stripe sessions
- adjust checkout payload validation to require product identifiers and record the selected shipping method
- update the shipping step to send product IDs to the API so shipping fees are added server-side

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dcddb59e2c83339a00f98afe1edcf8